### PR TITLE
Fixed memory leaks due to the registered functors at SparseConverter

### DIFF
--- a/examples/format_conversion/example_conversion.cpp
+++ b/examples/format_conversion/example_conversion.cpp
@@ -56,6 +56,10 @@ int main(){
     for(int i=0; i<nnz; i++)
         cout << coo3->adj[i] << ",";
     cout << endl;
-   
+
+    delete coo;
+    delete converter;
+    delete csr2;
+    delete coo3;
 }
 

--- a/sparsebase/include/sparsebase/SparsePreprocess.hpp
+++ b/sparsebase/include/sparsebase/SparsePreprocess.hpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 namespace sparsebase
 {

--- a/sparsebase/src/SparseConverter.cpp
+++ b/sparsebase/src/SparseConverter.cpp
@@ -1,6 +1,7 @@
 #include "sparsebase/SparseFormat.hpp"
 #include "sparsebase/SparseConverter.hpp"
 #include <iostream>
+#include <set>
 
 using namespace std;
 
@@ -135,6 +136,18 @@ namespace sparsebase
     template <typename ID_t, typename NNZ_t, typename VAL_t>
     SparseConverter<ID_t, NNZ_t, VAL_t>::~SparseConverter()
     {
+        set<uintptr_t> deleted_ptrs;
+
+        for(auto x : conversion_map){
+            for(auto y: x.second) {
+                ConversionFunctor<ID_t,NNZ_t,VAL_t>* ptr = y.second;
+                if(deleted_ptrs.count((uintptr_t) ptr) == 0){
+                    deleted_ptrs.insert((uintptr_t) ptr);
+                    delete ptr;
+                }
+            }
+        }
+
     }
 
     template <typename ID_t, typename NNZ_t, typename VAL_t>


### PR DESCRIPTION
Not the prettiest solution but it works for now. I avoided using smart pointers until we decide on the dynamic lifecycles. Also we might still want to use functions over functors. Valgrind still reports some leaked memory but this is due to the arrays inside SparseFormat instances as far as I understand.