### PR TITLE
SparseFormat Members Renamed

### DIFF
--- a/doxygen/pages/sparse_format.md
+++ b/doxygen/pages/sparse_format.md
@@ -16,9 +16,9 @@ class SparseFormat{
     virtual Format get_format() = 0;
     virtual std::vector<ID_t> get_dimensions() = 0;
     virtual NNZ_t get_num_nnz() = 0;
-    virtual NNZ_t * get_xadj() = 0;
-    virtual ID_t * get_adj() = 0;
-    virtual ID_t * get_is() = 0;
+    virtual NNZ_t * get_row_ptr() = 0;
+    virtual ID_t * get_col() = 0;
+    virtual ID_t * get_row() = 0;
     virtual VAL_t * get_vals() = 0;
     virtual ID_t ** get_ind() = 0;
 };
@@ -36,11 +36,11 @@ All classes that implement the Sparse Format interface store an enum type Format
     CSF_f=2 
   };
 ```
-As you might guess, not all concrete Sparse Formats have the same data members. For instance, compressed sparse rows (CSR) do not have `is` as a data member. So what happens if we call the `get_is()` function from the CSR class? 
+As you might guess, not all concrete Sparse Formats have the same data members. For instance, compressed sparse rows (CSR) do not have `is` as a data member. So what happens if we call the `get_row()` function from the CSR class? 
 
 ```cpp
     try{ //if the data member is invalid, sparse format throws an exception
-      auto is = csr->get_is();
+      auto is = csr->get_row();
     }
     catch(InvalidDataMember ex){
       cout << ex.what() << endl;
@@ -57,9 +57,9 @@ Currently Sparsebase supports two ways to create a sparse format:
 
 1. **User initialized.** The user passes the required data members of the respective sparse format through the constructor.
 ```cpp
-  unsigned int xadj[4] = {0, 2, 3, 4};
-  unsigned int adj[4] = {1,2,0,0};
-  CSR<unsigned int, unsigned int, void> csr(3, 3, xadj, adj, nullptr);
+  unsigned int row_ptr[4] = {0, 2, 3, 4};
+  unsigned int col[4] = {1,2,0,0};
+  CSR<unsigned int, unsigned int, void> csr(3, 3, row_ptr, col, nullptr);
 ```
 
 2. **Read directly from the file.** User first creates a reader by passing the file_name. Then calls the correct read function.

--- a/examples/custom_order/custom_order.cpp
+++ b/examples/custom_order/custom_order.cpp
@@ -27,7 +27,7 @@ vertex_type* degree_reorder_csr(std::vector<SparseFormat<vertex_type, edge_type,
   vertex_type *counts = new vertex_type[n]();
   for (vertex_type u = 0; u < n; u++)
   {
-    counts[csr->xadj[u + 1] - csr->xadj[u] + 1]++;
+    counts[csr->row_ptr[u + 1] - csr->row_ptr[u] + 1]++;
   }
   for (vertex_type u = 1; u < n; u++)
   {
@@ -38,7 +38,7 @@ vertex_type* degree_reorder_csr(std::vector<SparseFormat<vertex_type, edge_type,
   vertex_type *mr = new vertex_type[n]();
   for (vertex_type u = 0; u < n; u++)
   {
-    vertex_type ec = counts[csr->xadj[u + 1] - csr->xadj[u]];
+    vertex_type ec = counts[csr->row_ptr[u + 1] - csr->row_ptr[u]];
     sorted[ec + mr[ec]] = u;
     mr[ec]++;
   }
@@ -73,8 +73,8 @@ int main(int argc, char * argv[]){
   vertex_type * order = orderer.get_reorder(con, &params);
 
   vertex_type n = con->get_dimensions()[0];
-  auto xadj = con->get_xadj();
-  auto adj = con->get_adj();
+  auto xadj = con->get_row_ptr();
+  auto adj = con->get_col();
   cout << "According to degree order: " << endl;
   cout << "First vertex, ID: " << order[0] << ", Degree: " << xadj[order[0]+1] - xadj[order[0]] << endl;
   cout << "Last vertex, ID: " << order[n-1] << ", Degree: " << xadj[order[n-1]+1] - xadj[order[n-1]] << endl;
@@ -112,12 +112,12 @@ int main(int argc, char * argv[]){
 
   TransformInstance<vertex_type, edge_type, value_type, Transform> transformer(1);
   SparseFormat<vertex_type, edge_type, value_type> * csr = transformer.get_transformation(con, order);
-  auto * nxadj = csr->get_xadj();
-  auto * nadj = csr->get_adj();
+  auto * n_row_ptr = csr->get_row_ptr();
+  auto * n_col = csr->get_col();
   cout << "Checking the correctness of the transformation..." << endl;
   bool transform_is_correct = true;
   for(vertex_type i = 0; i < n-1 && transform_is_correct; i++){
-    if(nxadj[i+2] - nxadj[i+1] < nxadj[i+1] - nxadj[i])
+    if(n_row_ptr[i + 2] - n_row_ptr[i + 1] < n_row_ptr[i + 1] - n_row_ptr[i])
     {
       cout << "Transformation is incorrect!" << endl;
       transform_is_correct = false;

--- a/examples/degree_order/degree_order.cpp
+++ b/examples/degree_order/degree_order.cpp
@@ -35,11 +35,11 @@ int main(int argc, char * argv[]){
   SparseFormat<vertex_type, edge_type, value_type> * con = g.get_connectivity();
   vertex_type * order = orderer.get_reorder(con);
   vertex_type n = con->get_dimensions()[0];
-  auto xadj = con->get_xadj();
-  auto adj = con->get_adj();
+  auto row_ptr = con->get_row_ptr();
+  auto col = con->get_col();
   cout << "According to degree order: " << endl;
-  cout << "First vertex, ID: " << order[0] << ", Degree: " << xadj[order[0]+1] - xadj[order[0]] << endl;
-  cout << "Last vertex, ID: " << order[n-1] << ", Degree: " << xadj[order[n-1]+1] - xadj[order[n-1]] << endl;
+  cout << "First vertex, ID: " << order[0] << ", Degree: " << row_ptr[order[0] + 1] - row_ptr[order[0]] << endl;
+  cout << "Last vertex, ID: " << order[n-1] << ", Degree: " << row_ptr[order[n - 1] + 1] - row_ptr[order[n - 1]] << endl;
 
   cout << "********************************" << endl;
 
@@ -55,7 +55,7 @@ int main(int argc, char * argv[]){
       order_is_correct = false;
     }
     vertex_type u = order[i+1];
-    if(xadj[v+1] - xadj[v] > xadj[u+1] - xadj[u])
+    if(row_ptr[v + 1] - row_ptr[v] > row_ptr[u + 1] - row_ptr[u])
     {
       cout << "Degree Order is incorrect!" << endl;
       order_is_correct = false;
@@ -74,12 +74,12 @@ int main(int argc, char * argv[]){
 
   TransformInstance<vertex_type, edge_type, value_type, Transform> transformer(1);
   SparseFormat<vertex_type, edge_type, value_type> * csr = transformer.get_transformation(con, order);
-  auto * nxadj = csr->get_xadj();
-  auto * nadj = csr->get_adj();
+  auto * n_row_ptr = csr->get_row_ptr();
+  auto * n_col = csr->get_col();
   cout << "Checking the correctness of the transformation..." << endl;
   bool transform_is_correct = true;
   for(vertex_type i = 0; i < n-1 && transform_is_correct; i++){
-    if(nxadj[i+2] - nxadj[i+1] < nxadj[i+1] - nxadj[i])
+    if(n_row_ptr[i + 2] - n_row_ptr[i + 1] < n_row_ptr[i + 1] - n_row_ptr[i])
     {
       cout << "Transformation is incorrect!" << endl;
       transform_is_correct = false;

--- a/examples/format_conversion/example_conversion.cpp
+++ b/examples/format_conversion/example_conversion.cpp
@@ -8,11 +8,11 @@ using namespace sparsebase;
 
 int main(){
 
-    int adj[6] = {0,0,1,1,2,2};
-    int is[6] = {0,1,1,2,3,3};
+    int row[6] = {0, 0, 1, 1, 2, 2};
+    int col[6] = {0, 1, 1, 2, 3, 3};
     int vals[6] = {10, 20, 30, 40, 50, 60};
 
-    COO<int,int,int>* coo = new COO<int,int,int>(6,6,6,adj,is,vals);
+    COO<int,int,int>* coo = new COO<int,int,int>(6, 6, 6, row, col, vals);
 
     auto converter = new SparseConverter<int,int,int>();
     auto csr = converter->convert(coo,CSR_f);
@@ -30,11 +30,11 @@ int main(){
     cout << endl;
 
     for(int i=0; i<nnz; i++)
-        cout << csr2->adj[i] << ",";
+        cout << csr2->col[i] << ",";
     cout << endl;
     
     for(int i=0; i<n+1; i++)
-        cout << csr2->xadj[i] << ",";
+        cout << csr2->row_ptr[i] << ",";
     cout << endl;
     
     cout << endl;
@@ -50,11 +50,11 @@ int main(){
     cout << endl;
 
     for(int i=0; i<nnz; i++)
-        cout << coo3->is[i] << ",";
+        cout << coo3->row[i] << ",";
     cout << endl;
     
     for(int i=0; i<nnz; i++)
-        cout << coo3->adj[i] << ",";
+        cout << coo3->col[i] << ",";
     cout << endl;
 
     delete coo;

--- a/examples/rcm_order/rcm_order.cpp
+++ b/examples/rcm_order/rcm_order.cpp
@@ -32,8 +32,8 @@ int main(int argc, char * argv[]){
   ReorderInstance<vertex_type, edge_type, value_type, RCMReorder> orderer(1,4);
   SparseFormat<vertex_type, edge_type, value_type> * con = g.get_connectivity();
   vertex_type * order = orderer.get_reorder(con);
-  auto xadj = con->get_xadj();
-  auto adj = con->get_adj();
+  auto xadj = con->get_row_ptr();
+  auto adj = con->get_col();
   vertex_type n = con->get_dimensions()[0];
 
   cout << "********************************" << endl;

--- a/examples/sparse_format/csr_coo.cpp
+++ b/examples/sparse_format/csr_coo.cpp
@@ -11,14 +11,14 @@ using namespace sparsebase;
 
 int main(int argc, char * argv[]){
   cout << "F t re  s sp r e!" << endl;
-  unsigned int xadj[4] = {0, 2, 3, 4};
-  unsigned int adj[4] = {1,2,0,0};
+  unsigned int row_ptr[4] = {0, 2, 3, 4};
+  unsigned int col[4] = {1, 2, 0, 0};
   {
-    CSR<unsigned int, unsigned int, void> csr(3, 3, xadj, adj, nullptr);
+    CSR<unsigned int, unsigned int, void> csr(3, 3, row_ptr, col, nullptr);
     auto format = csr.get_format();
     auto dimensions = csr.get_dimensions();
-    auto xadj = csr.get_xadj();
-    auto adj = csr.get_adj();
+    auto row_ptr2 = csr.get_row_ptr();
+    auto col2 = csr.get_col();
     auto vals = csr.get_vals();
     cout << "Format: " << format << endl;
     cout << "# of dimensions: " << dimensions.size() << endl;
@@ -38,15 +38,15 @@ int main(int argc, char * argv[]){
     COO<unsigned int, unsigned int, void> * coo = reader.read_coo();
     auto format = coo->get_format();
     auto dimensions = coo->get_dimensions();
-    auto adj = coo->get_adj();
+    auto coo_col = coo->get_col();
     try{ //if the data member is invalid, sparse format throws an exception
-      auto xadj = coo->get_xadj();
+      auto coo_row_ptr = coo->get_row_ptr();
     }
-    catch(InvalidDataMember ex){
+    catch(InvalidDataMember& ex){
       cout << ex.what() << endl;
     }
-    auto is = coo->get_is();
-    auto vals = coo->get_vals();
+    auto coo_row = coo->get_row();
+    auto coo_vals = coo->get_vals();
     cout << "Format: " << coo->get_format() << endl;
     cout << "# of dimensions: " << dimensions.size() << endl;
     for(int i = 0; i < dimensions.size(); i++){

--- a/examples/sparse_reader/sparse_reader.cpp
+++ b/examples/sparse_reader/sparse_reader.cpp
@@ -25,8 +25,8 @@ int main(int argc, char * argv[]){
     auto coo = dynamic_cast<sparsebase::COO<vertex_type,edge_type,value_type>*>(g.get_connectivity());
 
     vertex_type nnz = coo->get_num_nnz();
-    vertex_type * adj = coo->get_adj();
-    vertex_type * is = coo->get_is();
+    vertex_type * col = coo->get_col();
+    vertex_type * row = coo->get_row();
 
     cout << "NNZ: " << nnz << endl;
 

--- a/sparsebase/include/sparsebase/SparseFormat.hpp
+++ b/sparsebase/include/sparsebase/SparseFormat.hpp
@@ -28,9 +28,9 @@ namespace sparsebase{
       virtual Format get_format() = 0;
       virtual std::vector<ID_t> get_dimensions() = 0;
       virtual NNZ_t get_num_nnz() = 0;
-      virtual NNZ_t * get_xadj() = 0;
-      virtual ID_t * get_adj() = 0;
-      virtual ID_t * get_is() = 0;
+      virtual NNZ_t * get_row_ptr() = 0;
+      virtual ID_t * get_col() = 0;
+      virtual ID_t * get_row() = 0;
       virtual VAL_t * get_vals() = 0;
       virtual ID_t ** get_ind() = 0;
   };
@@ -46,9 +46,9 @@ namespace sparsebase{
       virtual Format get_format() override;
       std::vector<ID_t>get_dimensions() override;
       NNZ_t get_num_nnz() override;
-      NNZ_t * get_xadj() override;
-      ID_t * get_adj() override;
-      ID_t * get_is() override;
+      NNZ_t * get_row_ptr() override;
+      ID_t * get_col() override;
+      ID_t * get_row() override;
       VAL_t * get_vals() override;
       ID_t ** get_ind() override;
 
@@ -62,28 +62,28 @@ namespace sparsebase{
   class COO : public AbstractSparseFormat<ID_t, NNZ_t, VAL_t>{
     public:
       COO();
-      COO(ID_t _n, ID_t _m, NNZ_t _nnz, ID_t * _adj, ID_t* _is, VAL_t* _vals);
+      COO(ID_t _n, ID_t _m, NNZ_t _nnz, ID_t* _row, ID_t * _col, VAL_t* _vals);
       virtual ~COO();
       Format get_format() override;
-      ID_t * adj;
-      ID_t * is;
+      ID_t * col;
+      ID_t * row;
       VAL_t * vals;
-      ID_t * get_adj() override;
-      ID_t * get_is() override;
+      ID_t * get_col() override;
+      ID_t * get_row() override;
       VAL_t * get_vals() override;
   };
   template<typename ID_t, typename NNZ_t, typename VAL_t>
   class CSR : public AbstractSparseFormat<ID_t, NNZ_t, VAL_t>{
     public:
       CSR();
-      CSR(ID_t _n, ID_t _m, NNZ_t *_xadj, ID_t *_adj, VAL_t *_vals);
+      CSR(ID_t _n, ID_t _m, NNZ_t *_row_ptr, ID_t *_col, VAL_t *_vals);
       Format get_format() override;
       virtual ~CSR();
-      NNZ_t * xadj;
-      ID_t * adj;
+      NNZ_t * row_ptr;
+      ID_t * col;
       VAL_t * vals;
-      ID_t * get_xadj() override;
-      ID_t * get_adj() override;
+      ID_t * get_row_ptr() override;
+      ID_t * get_col() override;
       VAL_t * get_vals() override;
   };
 

--- a/sparsebase/src/SparseFormat.cpp
+++ b/sparsebase/src/SparseFormat.cpp
@@ -40,19 +40,19 @@ namespace sparsebase
     }
 
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    NNZ_t * AbstractSparseFormat<ID_t, NNZ_t, VAL_t>::get_xadj()
+    NNZ_t * AbstractSparseFormat<ID_t, NNZ_t, VAL_t>::get_row_ptr()
     {
-        throw InvalidDataMember(to_string(get_format()), string("xadj"));
+        throw InvalidDataMember(to_string(get_format()), string("row_ptr"));
     }
 
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    ID_t * AbstractSparseFormat<ID_t, NNZ_t, VAL_t>::get_adj()
+    ID_t * AbstractSparseFormat<ID_t, NNZ_t, VAL_t>::get_col()
     {
-        throw InvalidDataMember(to_string(get_format()), string("adj"));
+        throw InvalidDataMember(to_string(get_format()), string("col"));
     }
 
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    ID_t * AbstractSparseFormat<ID_t, NNZ_t, VAL_t>::get_is()
+    ID_t * AbstractSparseFormat<ID_t, NNZ_t, VAL_t>::get_row()
     {
         throw InvalidDataMember(to_string(get_format()), string("is"));
     }
@@ -76,14 +76,14 @@ namespace sparsebase
         this->format = Format::COO_f;
         this->dimension = std::vector<ID_t>(2, 0);
         this->nnz = 0;
-        adj = nullptr;
+        col = nullptr;
         vals = nullptr;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    COO<ID_t, NNZ_t, VAL_t>::COO(ID_t _n, ID_t _m, NNZ_t _nnz, ID_t *_adj, ID_t *_is, VAL_t *_vals)
+    COO<ID_t, NNZ_t, VAL_t>::COO(ID_t _n, ID_t _m, NNZ_t _nnz, ID_t *_row, ID_t *_col, VAL_t *_vals)
     {
-        adj = _adj;
-        is = _is;
+        col = _col;
+        row = _row;
         vals = _vals;
         this->nnz = _nnz;
         this->format = Format::CSR_f;
@@ -95,14 +95,14 @@ namespace sparsebase
         return COO_f;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    ID_t * COO<ID_t, NNZ_t, VAL_t>::get_adj()
+    ID_t * COO<ID_t, NNZ_t, VAL_t>::get_col()
     {
-        return adj;
+        return col;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    ID_t * COO<ID_t, NNZ_t, VAL_t>::get_is()
+    ID_t * COO<ID_t, NNZ_t, VAL_t>::get_row()
     {
-        return is;
+        return row;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
     VAL_t * COO<ID_t, NNZ_t, VAL_t>::get_vals()
@@ -119,34 +119,34 @@ namespace sparsebase
         this->format = Format::CSR_f;
         this->dimension = std::vector<ID_t>(2, 0);
         this->nnz = 0;
-        this->adj = nullptr;
-        this->xadj = nullptr;
+        this->col = nullptr;
+        this->row_ptr = nullptr;
         this->vals = nullptr;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    CSR<ID_t, NNZ_t, VAL_t>::CSR(ID_t _n, ID_t _m, NNZ_t *_xadj, ID_t *_adj, VAL_t *_vals)
+    CSR<ID_t, NNZ_t, VAL_t>::CSR(ID_t _n, ID_t _m, NNZ_t *_row_ptr, ID_t *_col, VAL_t *_vals)
     {
-        this->xadj = _xadj;
-        this->adj = _adj;
+        this->row_ptr = _row_ptr;
+        this->col = _col;
         this->vals = _vals;
         this->format = Format::CSR_f;
         this->order = 2;
         this->dimension = {_n, _m};
-        this->nnz = this->xadj[this->dimension[0]];
+        this->nnz = this->row_ptr[this->dimension[0]];
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
     Format CSR<ID_t,NNZ_t,VAL_t>::get_format(){
         return CSR_f;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    ID_t * CSR<ID_t, NNZ_t, VAL_t>::get_adj()
+    ID_t * CSR<ID_t, NNZ_t, VAL_t>::get_col()
     {
-        return adj;
+        return col;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
-    ID_t * CSR<ID_t, NNZ_t, VAL_t>::get_xadj()
+    ID_t * CSR<ID_t, NNZ_t, VAL_t>::get_row_ptr()
     {
-        return xadj;
+        return row_ptr;
     }
     template <typename ID_t, typename NNZ_t, typename VAL_t>
     VAL_t * CSR<ID_t, NNZ_t, VAL_t>::get_vals()

--- a/sparsebase/src/SparsePreprocess.cpp
+++ b/sparsebase/src/SparsePreprocess.cpp
@@ -164,7 +164,7 @@ namespace sparsebase {
         ID_t n = csr->get_dimensions()[0];
         ID_t * counts = new ID_t[n]();
         for(ID_t u = 0; u < n; u++){
-          counts[csr->xadj[u+1] - csr->xadj[u]+1]++;
+          counts[csr->row_ptr[u + 1] - csr->row_ptr[u] + 1]++;
         }
         for(ID_t u = 1; u < n; u++){
           counts[u] += counts[u - 1];
@@ -173,7 +173,7 @@ namespace sparsebase {
         memset(sorted, -1, sizeof(ID_t) * n);
         ID_t * mr = new ID_t[n]();
         for(ID_t u = 0; u < n; u++){
-          ID_t ec = counts[csr->xadj[u+1] - csr->xadj[u]];
+          ID_t ec = counts[csr->row_ptr[u + 1] - csr->row_ptr[u]];
           sorted[ec + mr[ec]] = u;
           mr[ec]++;
         }
@@ -246,8 +246,8 @@ namespace sparsebase {
         CSR<ID_t, NNZ_t, VAL_t>* csr = static_cast<CSR<ID_t, NNZ_t, VAL_t>*>(formats[0]);
         RCMReorderParams* _params = static_cast<RCMReorderParams*>(params); 
         std::cout << "using the parameters " << _params->alpha << " and " << _params->beta << std::endl;
-        NNZ_t * xadj = csr->get_xadj();
-        ID_t * adj = csr->get_adj();
+        NNZ_t * xadj = csr->get_row_ptr();
+        ID_t * adj = csr->get_col();
         ID_t n = csr->get_dimensions()[0];
         ID_t *Q = new ID_t[n];
 
@@ -339,8 +339,8 @@ namespace sparsebase {
       ID_t n = dimensions[0];
       ID_t m = dimensions[1];
       NNZ_t nnz = sp->get_num_nnz();
-      NNZ_t * xadj = sp->get_xadj();
-      ID_t * adj = sp->get_adj();
+      NNZ_t * xadj = sp->get_row_ptr();
+      ID_t * adj = sp->get_col();
       VAL_t * vals = sp->get_vals();
       NNZ_t * nxadj = new ID_t[n+1]();
       ID_t * nadj = new NNZ_t[nnz]();

--- a/sparsebase/src/SparseReader.cpp
+++ b/sparsebase/src/SparseReader.cpp
@@ -63,36 +63,36 @@ namespace sparsebase
       edges.erase(unique(edges.begin(), edges.end()), edges.end());
 
       //allocate the memory
-      e_t *xadj = new e_t[n + 1];
-      v_t *adj = new v_t[m];
+      e_t *row_ptr = new e_t[n + 1];
+      v_t *col = new v_t[m];
       v_t *tadj = new v_t[m];
       v_t *is = new v_t[m];
 
-      //populate adj and xadj
-      memset(xadj, 0, sizeof(e_t) * (n + 1));
+      //populate col and row_ptr
+      memset(row_ptr, 0, sizeof(e_t) * (n + 1));
       int mt = 0;
       for (std::pair<v_t, v_t> &e : edges)
       {
-        xadj[e.first + 1]++;
+        row_ptr[e.first + 1]++;
         is[mt] = e.first;
-        adj[mt++] = e.second;
+        col[mt++] = e.second;
       }
 
       for (e_t i = 1; i <= n; i++)
       {
-        xadj[i] += xadj[i - 1];
+          row_ptr[i] += row_ptr[i - 1];
       }
 
       for (v_t i = 0; i < m; i++)
       {
-        tadj[i] = xadj[adj[i]]++;
+        tadj[i] = row_ptr[col[i]]++;
       }
       for (e_t i = n; i > 0; i--)
       {
-        xadj[i] = xadj[i - 1];
+          row_ptr[i] = row_ptr[i - 1];
       }
-      xadj[0] = 0;
-      return new CSR<v_t, e_t, w_t>(n, n, xadj, adj, nullptr);
+        row_ptr[0] = 0;
+      return new CSR<v_t, e_t, w_t>(n, n, row_ptr, col, nullptr);
     }
     else
     {
@@ -137,8 +137,8 @@ namespace sparsebase
 
         fin >> M >> N >> L;
 
-        v_t* adj = new v_t[L];
-        v_t* is = new v_t[L];
+        v_t* row = new v_t[L];
+        v_t* col = new v_t[L];
         if constexpr(!std::is_same_v<void,w_t>) {
             if(weighted){
                 w_t* vals = new w_t[L];
@@ -146,12 +146,12 @@ namespace sparsebase
                     v_t m, n;
                     w_t w;
                     fin >> m >> n >> w;
-                    adj[l] = m-1;
-                    is[l] = n-1;
+                    row[l] = n - 1;
+                    col[l] = m - 1;
                     vals[l] = w;
                 }
 
-                auto coo = new COO<v_t,e_t,w_t>(M,N,L,adj,is,vals);
+                auto coo = new COO<v_t,e_t,w_t>(M, N, L, row, col, vals);
                 return coo;
             } else {
                 // TODO: Add an exception class for this
@@ -161,11 +161,11 @@ namespace sparsebase
             for (e_t l = 0; l < L; l++) {
                 v_t m, n;
                 fin >> m >> n;
-                adj[l] = m-1;
-                is[l] = n-1;
+                row[l] = m - 1;
+                col[l] = n - 1;
             }
 
-            auto coo = new COO<v_t, e_t, w_t>(M,N,L,adj,is,nullptr);
+            auto coo = new COO<v_t, e_t, w_t>(M, N, L, row, col, nullptr);
             return coo;
         }
     }


### PR DESCRIPTION
Renamed inner members of SparseFormat class; also changed variable names in examples for consistency. No changes were made to the CSF format as we have not fully decided on how to handle 3+ dimensional data.