### PR TITLE
Removed installing GTest with SparseBase

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(Tests)
 
-add_subdirectory(lib)
+add_subdirectory(lib EXCLUDE_FROM_ALL)
 
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_source_dir})
 


### PR DESCRIPTION
Due to a mistake in testing CMakeLists, GTest was being installed with SparseBase when installing the library.