### PR TITLE
Github Actions Setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: CMake
+
+on:
+  # This action will activate on pushes and pull requests to the branches specified below
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+env:
+  # CMake Build Type
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # For now the actions is only performed on ubuntu
+    # However in future we should go for multiple operating systems
+    # See: https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/2
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Data
+      run: cp -r ${{github.workspace}}/examples/data ${{github.workspace}}/build/examples/
+
+    - name: Examples
+      working-directory: ${{github.workspace}}/build/examples
+      run: >-
+        ./custom_order/custom_order ./data/com-dblp.uedgelist ;
+        ./degree_order/degree_order ./data/com-dblp.uedgelist ;
+        ./rcm_order/rcm_order ./data/com-dblp.uedgelist ;
+        ./format_conversion/example_conversion ;
+        ./sparse_format/csr_coo ./data/ash958.mtx ;
+        ./sparse_reader/sparse_reader ./data/ash958.mtx ;
+      
+    # Tests are turned off for now since we don't have any
+    #- name: Test
+      #working-directory: ${{github.workspace}}/build
+      #run: ctest -C ${{env.BUILD_TYPE}}
+      


### PR DESCRIPTION
This is a minimal setup for github actions to do the following tasks:
- Configure and build the library in release mode.
- Run all the examples.

This action will be performed on every push and pull-request to the `main` and `develop` branches. As a result I believe it has to be merged into `main`, it shouldn't cause any conflicts. I already tested the action on a private repository and it worked fine.

For now the action will be performed on the latest ubuntu image (at the time of writing it uses `gcc 9`). It is possible to use multiple operating systems each with different compilers. So we should be looking into doing that in the future.

Also currently it will not run the tests as we don't have any. But this functionality is very easy to add.