### PR TITLE
Automatic Testing with Github Actions (Initial Setup)

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DRUN_TESTS=ON
 
     - name: Build
       # Build your program with the given configuration
@@ -42,11 +42,8 @@ jobs:
         ./format_conversion/example_conversion
         ./sparse_format/csr_coo ./data/ash958.mtx
         ./sparse_reader/sparse_reader ./data/ash958.mtx
-      
 
-    #- name: Test
-     # working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      #run: ctest -C ${{env.BUILD_TYPE}}
+    - name: Run Tests
+      working-directory: ${{github.workspace}}/build
+      run: ctest -V
       

--- a/.github/workflows/testing_main.yml
+++ b/.github/workflows/testing_main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DRUN_TESTS=ON
 
     - name: Build
       # Build your program with the given configuration
@@ -42,11 +42,8 @@ jobs:
         ./format_conversion/example_conversion
         ./sparse_format/csr_coo ./data/ash958.mtx
         ./sparse_reader/sparse_reader ./data/ash958.mtx
-      
 
-    #- name: Test
-     # working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      #run: ctest -C ${{env.BUILD_TYPE}}
+    - name: Run Tests
+      working-directory: ${{github.workspace}}/build
+      run: ctest -V
       


### PR DESCRIPTION
The original pull request for reference: #49 

Two actions will be added by this pull request:
- Testing Main (for the `main` branch)
- Testing Develop (for the `develop` branch)

Their operation is mostly identical they will perform the following on any pull request or push to their respective branch:
1. Configure & build the library using cmake
2. Run all the examples
3. Run all the tests (currently disabled since we don't have any tests)

Github will notify us in various places if any of these actions terminate in an unsuccessful exit code. From now on we shouldn't approve or merge any pull request until these actions are passed.

The difference between the two is quite minor. Testing Main will perform these actions in both Ubuntu and MacOS (and Windows in the future) where as Testing Develop will only use Ubuntu. This is mainly due to the MacOS servers being relatively slow (Ubuntu servers were twice as fast on my tests). We don't want to wait large amounts of time on every pull request to develop as these will be numerous. But releases and hotfixes will be tested using both Ubuntu (with gcc) and MacOS (with clang) which gives us a good coverage.
