### PR TITLE
Automatic Doc Generation with Github Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pull request introduces an action to automatically build & deploy our doxygen/sphinx documentation on every push to main (on every release and hotfix merge). The documentation will then be accessible through github pages. This is done by putting the generated documentation to a separate branch of its own called `gh-pages`. This is the standard name most people use but it can be changed if you have a better idea.