### PR TITLE
Use "Debug" build type for automatic testing on the develop branch

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:


### PR DESCRIPTION
With the current setup automatic testing using Github Actions takes ~5 minutes on the `develop` branch and ~10 minutes (~18 CPU minutes due to this involving two separate runs) on the `main` branch. These are performed on every pull request, commit to a pull request and merge to the respective branch. 

There are 2 issues with this:
- It slows down the development since we need to wait for the tests before we can merge.
- As this is a private repository, we only have a limited number of minutes for using actions.

We can improve the situation for now by using "Debug" build type on cmake for the `develop` tests (which lowers the time to less than 1 minute). I believe it is not a good idea to do the same for `main` tests as this would reduce our coverage during releases and hotfixes.