### PR TITLE
Fixed typo in compilation steps with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.0 )
 
-project( SparseBase_project VERSION 0.1.4 )
+project( SparseBase_project VERSION 0.1.5 )
 option(RUN_TESTS "Enable running tests" OFF)
 
 include( CheckCXXCompilerFlag )

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ SparseBase can be easily added to your project either through CMake's `find_pack
 ### Adding SparseBase through CMake
 If you installed SparseBase to the default system directory, use the following the command in your `CMakeLists.txt` file to add the library to your project:
 ```cmake
-find_package(sparsebase 0.1.4 REQUIRED)
+find_package(sparsebase 0.1.5 REQUIRED)
 ```
 However, if you installed the library to a different path, say `/custom/location/`, you must specify that path in the command:
 ```cmake
-find_package(sparsebase 0.1.4 REQUIRED PATHS /custom/location/)
+find_package(sparsebase 0.1.5 REQUIRED PATHS /custom/location/)
 ```
 After the library is added to your project, you can simply link your targets to `sparsebase::sparsebase`:
 
@@ -88,7 +88,7 @@ Users can run unit tests easily after building the project. To do so, they must 
 ```bash
 mkdir build # if a build directory doesn't exist
 cd build
-cmake -DRUN_TESTS ..
+cmake -DRUN_TESTS=ON ..
 ```
 Once its built, while in the build directory, do the following:
 ```bash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, SparCity Project'
 author = 'SparCity Project Members'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.1.4'
+release = 'v0.1.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -55,11 +55,11 @@ SparseBase can be easily added to your project either through CMake's `find_pack
 #### Adding SparseBase through CMake
 If you installed SparseBase to the default system directory, use the following the command in your `CMakeLists.txt` file to add the library to your project:
 ```cmake
-find_package(sparsebase 0.1.4 REQUIRED)
+find_package(sparsebase 0.1.5 REQUIRED)
 ```
 However, if you installed the library to a different path, say `/custom/location/`, you must specify that path in the command:
 ```cmake
-find_package(sparsebase 0.1.4 REQUIRED PATHS /custom/location/)
+find_package(sparsebase 0.1.5 REQUIRED PATHS /custom/location/)
 ```
 After the library is added to your project, you can simply link your targets to `sparsebase::sparsebase`:
 
@@ -83,7 +83,7 @@ Users can run unit tests easily after building the project. To do so, they must 
 ```bash
 mkdir build # if a build directory doesn't exist
 cd build
-cmake -DRUN_TESTS ..
+cmake -DRUN_TESTS=ON ..
 ```
 Once its built, while in the build directory, do the following:
 ```bash


### PR DESCRIPTION
In the Getting Started page and in the README.md file, the command to `cmake` with tests had a typo. That typo was fixed.