### PR TITLE
Formatter was using old file extensions

### DIFF
--- a/.format.bash
+++ b/.format.bash
@@ -1,2 +1,2 @@
 #! /bin/bash
-find ${1}/sparsebase/ -iname *.hpp -o -iname *.cpp | xargs clang-format -i 
+find ${1}/sparsebase/ -iname *.h -o -iname *.cc | xargs clang-format -i 


### PR DESCRIPTION
Formatter was using the old file extensions (`.hpp` and `.cpp`) instead of the Google standard ones (`.h` and `.cc`.)