### PR TITLE
Added move transform

### DIFF
--- a/sparsebase/include/sparsebase/sparse_preprocess.h
+++ b/sparsebase/include/sparsebase/sparse_preprocess.h
@@ -140,6 +140,20 @@ public:
 };
 
 template <typename IDType, typename NNZType, typename ValueType>
+class MoveTransform : public TransformPreprocessType<IDType, NNZType, ValueType> {
+public:
+  MoveTransform(IDType*);
+  struct TransformParams : PreprocessParams {
+    IDType* order;
+    TransformParams(IDType* order):order(order){};
+  };
+
+protected:
+  static format::Format *
+  MoveTransformCSR(std::vector<format::Format *> formats,
+                PreprocessParams*);
+};
+template <typename IDType, typename NNZType, typename ValueType>
 class Transform : public TransformPreprocessType<IDType, NNZType, ValueType> {
 public:
   Transform(IDType*);


### PR DESCRIPTION
Added a new Transform implementation that carries out move transforms. In other words, it will not store the same format twice. Instead, when format A is transformed into format B, the data of format A is deleted.

Changes:

- Added a new `TrasnformPreprocessType`: `MoveTransform`.
- The move transform function will use auxiliary data to carry out the conversion (it's not in-place) but the old format (before conversion.) is deleted at the end of conversion.