### PR TITLE
GitHub Actions Windows Examples Fix

### DIFF
--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -23,6 +23,10 @@ def run_example(exe_filename, data_filename):
     dir_path = os.path.dirname(__file__)
     exe_path = os.path.join(dir_path, exe_filename, exe_filename)
 
+    # Windows executables have ".exe" extension
+    if os.name == "nt":
+        exe_path += ".exe"
+
     if not os.path.exists(exe_path):
         print("Example is not built, skipping: ", exe_filename)
         return


### PR DESCRIPTION
When the example codes are built in Windows, they are automatically given a `.exe` extension. As a result the `run_all_examples.py` script used by Github Actions ignored these executables since their names did not match what was expected. This PR should fix that issue.