### PR TITLE
Fixed doc and license links to reflect organization change

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ It is designed with HPC (High Performance Computing) usage at the forefront. It 
 
 The library is still in early stages of development. As a result, the API is not stable and likely to change in the near future.
 
-:rocket: [Installation & Basic Usage](https://su-hpc.github.io/sparsebase/pages/getting_started.html)
+:rocket: [Installation & Basic Usage](https://sparcityeu.github.io/sparsebase/pages/getting_started.html)
 
-:computer: [Source Code](https://github.com/SU-HPC/sparsebase)
+:computer: [Source Code](https://github.com/sparcityeu/sparsebase)
 
-:books: [Documentation](https://su-hpc.github.io/sparsebase/)
+:books: [Documentation](https://sparcityeu.github.io/sparsebase/)
 
-:scroll: [License](https://github.com/SU-HPC/sparsebase/blob/main/LICENSE)
+:scroll: [License](https://sparcityeu.github.io/sparsebase/pages/license.html)
 
-:heart: [Contribution Guide](https://su-hpc.github.io/sparsebase/pages/contributing/index.html)
+:heart: [Contribution Guide](https://sparcityeu.github.io/sparsebase/pages/contributing/index.html)

--- a/src/sparsebase/context/context.h
+++ b/src/sparsebase/context/context.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_CONTEXT_CONTEXT_H_
 #define SPARSEBASE_SPARSEBASE_CONTEXT_CONTEXT_H_

--- a/src/sparsebase/context/cuda/context.cuh
+++ b/src/sparsebase/context/cuda/context.cuh
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_CONTEXT_CUDA_CONTEXT_H_
 #define SPARSEBASE_SPARSEBASE_CONTEXT_CUDA_CONTEXT_H_

--- a/src/sparsebase/feature/feature.h
+++ b/src/sparsebase/feature/feature.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_FEATURE_FEATURE_H_
 #define SPARSEBASE_SPARSEBASE_FEATURE_FEATURE_H_

--- a/src/sparsebase/format/cuda/format.cuh
+++ b/src/sparsebase/format/cuda/format.cuh
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #include "sparsebase/context/context.h"
 #include "sparsebase/context/cuda/context.cuh"

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_FORMAT_FORMAT_H_
 #define SPARSEBASE_SPARSEBASE_FORMAT_FORMAT_H_

--- a/src/sparsebase/object/object.h
+++ b/src/sparsebase/object/object.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_OBJECT_OBJECT_H_
 #define SPARSEBASE_SPARSEBASE_OBJECT_OBJECT_H_

--- a/src/sparsebase/preprocess/cuda/preprocess.cuh
+++ b/src/sparsebase/preprocess/cuda/preprocess.cuh
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_PREPROCESS_CUDA_PREPROCESS_H_
 #define SPARSEBASE_SPARSEBASE_PREPROCESS_CUDA_PREPROCESS_H_

--- a/src/sparsebase/preprocess/preprocess.h
+++ b/src/sparsebase/preprocess/preprocess.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_PREPROCESS_PREPROCESS_H_
 #define SPARSEBASE_SPARSEBASE_PREPROCESS_PREPROCESS_H_

--- a/src/sparsebase/sparsebase.h
+++ b/src/sparsebase/sparsebase.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_H_
 #define SPARSEBASE_SPARSEBASE_H_

--- a/src/sparsebase/utils/converter/converter.h
+++ b/src/sparsebase/utils/converter/converter.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_UTILS_CONVERTER_CONVERTER_H_
 #define SPARSEBASE_SPARSEBASE_UTILS_CONVERTER_CONVERTER_H_

--- a/src/sparsebase/utils/converter/cuda/converter.cuh
+++ b/src/sparsebase/utils/converter/cuda/converter.cuh
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #include "sparsebase/format/cuda/format.cuh"
 #include "sparsebase/format/format.h"

--- a/src/sparsebase/utils/exception.h
+++ b/src/sparsebase/utils/exception.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_UTILS_EXCEPTION_H_
 #define SPARSEBASE_SPARSEBASE_UTILS_EXCEPTION_H_

--- a/src/sparsebase/utils/io/reader.h
+++ b/src/sparsebase/utils/io/reader.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_UTILS_IO_READER_H_
 #define SPARSEBASE_SPARSEBASE_UTILS_IO_READER_H_

--- a/src/sparsebase/utils/io/sparse_file_format.h
+++ b/src/sparsebase/utils/io/sparse_file_format.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_UTILS_IO_SPARSE_FILE_FORMAT_H_
 #define SPARSEBASE_SPARSEBASE_UTILS_IO_SPARSE_FILE_FORMAT_H_

--- a/src/sparsebase/utils/io/writer.h
+++ b/src/sparsebase/utils/io/writer.h
@@ -4,7 +4,7 @@
  *
  * This file is distributed under MIT license.
  * The complete license agreement can be obtained at:
- * https://github.com/SU-HPC/sparsebase/blob/main/LICENSE
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
 #ifndef SPARSEBASE_SPARSEBASE_UTILS_IO_WRITER_H_
 #define SPARSEBASE_SPARSEBASE_UTILS_IO_WRITER_H_


### PR DESCRIPTION
The organization of the SparseBase repo was changed from SU-HPC to sparcityeu, so we changed the links in the docs and README.md and in the code to reflect these changes.