### PR TITLE
Hotfix/v0.2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ else()
   cmake_policy(VERSION 3.18)
 endif()
 
-project( SparseBase_project VERSION 0.2.2 )
+project( SparseBase_project VERSION 0.2.4 )
 option(RUN_TESTS "Enable running tests" OFF)
 option(_HEADER_ONLY "Use the library as a header only library?" OFF)
 option(CUDA "Enable CUDA" OFF)

--- a/examples/csr_coo/csr_coo.cc
+++ b/examples/csr_coo/csr_coo.cc
@@ -41,8 +41,9 @@ int main(int argc, char *argv[]) {
 
   {
     string file_name = argv[1];
+    bool weighted = false;
     utils::io::MTXReader<unsigned int, unsigned int, unsigned int> reader(
-        file_name);
+        file_name, weighted);
     format::COO<unsigned int, unsigned int, unsigned int> *coo =
         reader.ReadCOO();
     auto format = coo->get_format_id();

--- a/examples/sparse_feature/sparse_feature.cc
+++ b/examples/sparse_feature/sparse_feature.cc
@@ -26,8 +26,9 @@ int main(int argc, char *argv[]) {
   }
 
   string file_name = argv[1];
+  bool weighted = false;
   sparsebase::utils::io::MTXReader<vertex_type, edge_type, value_type> reader(
-      file_name);
+      file_name, weighted);
   COO<vertex_type, edge_type, value_type> *coo = reader.ReadCOO();
   context::CPUContext cpu_context;
 

--- a/examples/sparse_reader/sparse_reader.cc
+++ b/examples/sparse_reader/sparse_reader.cc
@@ -19,6 +19,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
   string file_name = argv[1];
+  bool weighted = false;
 
   // Reading the mtx into a graph object
   // auto reader = new sparsebase::MTXReader<vertex_type, edge_type,
@@ -26,7 +27,7 @@ int main(int argc, char *argv[]) {
   object::Graph<vertex_type, edge_type, value_type> g;
   g.ReadConnectivityToCOO(
       sparsebase::utils::io::MTXReader<vertex_type, edge_type, value_type>(
-          file_name));
+          file_name, weighted));
 
   cout << "Number of vertices: " << g.n_ << endl;
   cout << "Number of edges: " << g.m_ << endl;

--- a/src/sparsebase/feature/feature.cc
+++ b/src/sparsebase/feature/feature.cc
@@ -139,12 +139,12 @@ Extractor::Extract(format::Format *format,
   // match and get classes for format extraction
   std::vector<preprocess::ExtractableType *> cs = this->GetClasses(in_);
   std::unordered_map<std::type_index, std::any> res;
-  std::cout << std::endl << "Classes used:" << std::endl;
+  //std::cout << std::endl << "Classes used:" << std::endl;
   for (auto &el : cs) {
-    std::cout << el->get_feature_id().name() << std::endl;
+    //std::cout << el->get_feature_id().name() << std::endl;
     res.merge(el->Extract(format, c));
   }
-  std::cout << std::endl;
+  //std::cout << std::endl;
   return res;
 }
 

--- a/src/sparsebase/object/object.cc
+++ b/src/sparsebase/object/object.cc
@@ -114,7 +114,7 @@ void Graph<VertexID, NumEdges, Weight>::ReadConnectivityFromEdgelistToCSR(
 template <typename VertexID, typename NumEdges, typename Weight>
 void Graph<VertexID, NumEdges, Weight>::ReadConnectivityFromMTXToCOO(
     std::string filename) {
-  utils::io::MTXReader<VertexID, NumEdges, Weight> reader(filename);
+  utils::io::MTXReader<VertexID, NumEdges, Weight> reader(filename, false);
   this->set_connectivity(reader.ReadCOO(), true);
   this->VerifyStructure();
   InitializeInfoFromConnection();

--- a/src/sparsebase/object/object.cc
+++ b/src/sparsebase/object/object.cc
@@ -88,8 +88,8 @@ void Graph<VertexID, NumEdges, Weight>::ReadConnectivityToCOO(
   this->set_connectivity(reader.ReadCOO(), true);
   this->VerifyStructure();
   InitializeInfoFromConnection();
-  std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
-            << this->connectivity_->get_dimensions()[1] << std::endl;
+  //std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
+  //          << this->connectivity_->get_dimensions()[1] << std::endl;
 }
 template <typename VertexID, typename NumEdges, typename Weight>
 void Graph<VertexID, NumEdges, Weight>::ReadConnectivityToCSR(
@@ -97,8 +97,8 @@ void Graph<VertexID, NumEdges, Weight>::ReadConnectivityToCSR(
   this->set_connectivity(reader.ReadCSR(), true);
   this->VerifyStructure();
   InitializeInfoFromConnection();
-  std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
-            << this->connectivity_->get_dimensions()[1] << std::endl;
+  ///std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
+  ///          << this->connectivity_->get_dimensions()[1] << std::endl;
 }
 template <typename VertexID, typename NumEdges, typename Weight>
 void Graph<VertexID, NumEdges, Weight>::ReadConnectivityFromEdgelistToCSR(
@@ -108,8 +108,8 @@ void Graph<VertexID, NumEdges, Weight>::ReadConnectivityFromEdgelistToCSR(
   this->set_connectivity(reader.ReadCSR(), true);
   this->VerifyStructure();
   InitializeInfoFromConnection();
-  std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
-            << this->connectivity_->get_dimensions()[1] << std::endl;
+  ///std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
+  ///          << this->connectivity_->get_dimensions()[1] << std::endl;
 }
 template <typename VertexID, typename NumEdges, typename Weight>
 void Graph<VertexID, NumEdges, Weight>::ReadConnectivityFromMTXToCOO(
@@ -118,8 +118,8 @@ void Graph<VertexID, NumEdges, Weight>::ReadConnectivityFromMTXToCOO(
   this->set_connectivity(reader.ReadCOO(), true);
   this->VerifyStructure();
   InitializeInfoFromConnection();
-  std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
-            << this->connectivity_->get_dimensions()[1] << std::endl;
+  ///std::cout << "dimensions " << this->connectivity_->get_dimensions()[0] << ", "
+  ///          << this->connectivity_->get_dimensions()[1] << std::endl;
 }
 template <typename VertexID, typename NumEdges, typename Weight>
 Graph<VertexID, NumEdges, Weight>::Graph() {}

--- a/src/sparsebase/utils/converter/converter.cc
+++ b/src/sparsebase/utils/converter/converter.cc
@@ -373,6 +373,27 @@ bool Converter::CanConvert(std::type_index from_type,
   }
   return false;
 }
+
+  void Converter::ClearConversionFunctions(std::type_index from_type, std::type_index to_type, bool move_conversion){
+    auto map = get_conversion_map(move_conversion);
+    if (map->find(from_type) != map->end()){
+      if ((*map)[from_type].find(to_type)!= (*map)[from_type].end()){
+        (*map)[from_type].erase(to_type);
+        if ((*map)[from_type].size() == 0) map->erase(from_type);
+      }
+    }
+  }
+  
+  /*! Removes all conversion functions from the current converter
+   */
+  void Converter::ClearConversionFunctions(bool move_conversion){
+    auto map = get_conversion_map(move_conversion);
+    map->clear();
+  }
+  
+  /*! Removes all move conversion functions from the current converter
+   */
+  void ClearMoveConversionFunctions(std::type_index from_type, std::type_index to_type);
 std::vector<Format *>
 Converter::ApplyConversionSchema(ConversionSchemaConditional cs,
                                  std::vector<Format *> packed_sfs,

--- a/src/sparsebase/utils/converter/converter.h
+++ b/src/sparsebase/utils/converter/converter.h
@@ -126,6 +126,19 @@ public:
                   std::type_index to_type, context::Context *to_context,
                   bool is_move_conversion = false);
 
+  /*! Removes conversion functions that convert from `from_type` to `to_type` from
+   * the conversion map
+   * @param from_type type_index of the original format type
+   * @param to_type type_index of the destination format type
+   * @param move_conversion whether the conversions to be removed are move conversions or not
+   */
+  void ClearConversionFunctions(std::type_index from_type, std::type_index to_type, bool move_conversion = false);
+  
+  /*! Removes all conversion functions from the current converter
+   * @param move_conversion whether the conversions to be removed are move conversions or not
+   */
+  void ClearConversionFunctions(bool move_conversion = false);
+  
   std::vector<format::Format *>
   ApplyConversionSchema(ConversionSchemaConditional cs,
                         std::vector<format::Format *> packed_sfs,

--- a/src/sparsebase/utils/io/reader.h
+++ b/src/sparsebase/utils/io/reader.h
@@ -113,7 +113,7 @@ public:
    * @param convert_to_zero_index if set to true the indices will be converted
    * such that they start from 0 instead of 1
    */
-  explicit MTXReader(std::string filename, bool weighted = false,
+  explicit MTXReader(std::string filename, bool weighted,
                      bool convert_to_zero_index = true);
   format::COO<IDType, NNZType, ValueType> *ReadCOO() const override;
   format::CSR<IDType, NNZType, ValueType> *ReadCSR() const override;
@@ -136,7 +136,7 @@ class PigoMTXReader : public Reader,
                       public ReadsCOO<IDType, NNZType, ValueType>,
                       public ReadsCSR<IDType, NNZType, ValueType> {
 public:
-  PigoMTXReader(std::string filename, bool weighted = false,
+  PigoMTXReader(std::string filename, bool weighted,
                 bool convert_to_zero_index = true);
   format::COO<IDType, NNZType, ValueType> *ReadCOO() const override;
   format::CSR<IDType, NNZType, ValueType> *ReadCSR() const override;
@@ -159,7 +159,7 @@ class PigoEdgeListReader : public Reader,
                            public ReadsCSR<IDType, NNZType, ValueType>,
                            public ReadsCOO<IDType, NNZType, ValueType> {
 public:
-  PigoEdgeListReader(std::string filename, bool weighted = false);
+  PigoEdgeListReader(std::string filename, bool weighted);
   format::CSR<IDType, NNZType, ValueType> *ReadCSR() const override;
   format::COO<IDType, NNZType, ValueType> *ReadCOO() const override;
   virtual ~PigoEdgeListReader() = default;

--- a/tests/suites/sparsebase/utils/io/reader_tests.cc
+++ b/tests/suites/sparsebase/utils/io/reader_tests.cc
@@ -60,7 +60,7 @@ TEST(MTXReader, Basics) {
   ofs2.close();
 
   // Read non-weighted file using sparsebase
-  sparsebase::utils::io::MTXReader<int, int, int> reader("test.mtx");
+  sparsebase::utils::io::MTXReader<int, int, int> reader("test.mtx", false);
   auto coo = reader.ReadCOO();
 
   // Check the dimensions
@@ -236,7 +236,7 @@ TEST(PigoEdgeListReader, Basics) {
   ofs2.close();
 
   sparsebase::utils::io::PigoEdgeListReader<int, int, int> reader(
-      "test_pigo.edges");
+      "test_pigo.edges", false);
   auto coo = reader.ReadCOO();
 
   // Check the dimensions (double the edges due to undirected read)


### PR DESCRIPTION
A few small fixes to address the usage report done by @konstapo.

- Commented out prints in the `sparsebase::feature::Extractor` and `sparsebase::object::Graph` classes (until verbosity is formally added to the library).
- Made the "weighted" parameter in Matrix Market readers non-optional. This will force users to explicitly state whether the matrix market file they are reading contains weights or not. This is a temporary solution until a reader that infers this information automatically is added (effort already started in #125).
- Added functions to clear conversion functions from `sparsebase::utils::converter::Converter` classes, as well as some tests related to them.