### PR TITLE
Easy Convert function and Format seperation

### DIFF
--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -221,17 +221,25 @@ auto csr = reader2->ReadCSR();
 
 ### Casting Formats
 
-Many function in the library return generic ``Format`` pointers to ensure flexibility.
-These pointers can easily be converted into concrete versions using the ``As<>()`` function of the
-``Format`` class.
+Many functions in the library return generic format pointers like ``FormatOrderTwo`` or ``FormatOrderOne`` to ensure flexibility. These pointers can easily be converted into concrete versions using the ``Convert<>()`` member function. 
+
+```cpp
+// Consider the scenario where you obtained a generic pointer from a function
+sparsebase::format::FormatOrderTwo<int, int, int>* format = ...;
+
+// If the type of this pointer is known, then you can simply use the Convert function
+sparsebase::format::CSR<int,int,int>* csr = format->Convert<sparsebase::format::CSR>();
+
+```
+
+Alternatively, if the pointer you have is to the abstract ``Format`` class, then you should use the ``As<>()`` casting function. Keep in mind that you must pass, as a template argument to ``As<>()``, the format class you wish to cast to along with its templated types:
 
 ```cpp
 // Consider the scenario where you obtained a generic pointer from a function
 sparsebase::format::Format* format = ...;
 
-// If the type of this pointer is known, then you can simply use the As function
-// If the type is not known you can use the converters described in the next section
-sparsebase::format::CSR<int,int,int>* csr = format->As<sparsebase::format::CSR<int,int,int>>();
+// The template argument includes the class name along with its template types (int, int, int)
+sparsebase::format::CSR<int,int,int>* csr = format->As<sparsebase::format::CSR<int, int, int>>();
 
 ```
 
@@ -240,22 +248,19 @@ sparsebase::format::CSR<int,int,int>* csr = format->As<sparsebase::format::CSR<i
 
 As explained in the previous section, readers will read to different formats.
 
-However, we can convert the data into the format we desire using ``Converter``:
+However, we can convert the data into the format we desire using the ``Convert`` member funciton:
 ```cpp
 // Consider the scenario where you obtained a COO and want to convert it to a CSR
 auto coo = ...; 
 
-// Converter instances automatically select the correct conversion function and apply it
-auto converter = sparsebase::utils::converter::Converter<vertex_type, edge_type, value_type>();
-
-// Since we don't want the result to be in a device, we will use a default CPUContext here
+// Since we don't want the result to be in a external device such as a GPU, we will use a default CPUContext here
 sparsebase::context::CPUContext cpu_context;
 
 // Convert<>() function will convert to the desired format and cast the pointer to the right type
 // The final parameter being true indicates a move conversion will be performed
 // This will be faster but will invalidate the original coo matrix
 // If both the coo and csr are needed you should pass false here
-auto csr = converter.Convert<sparsebase::format::CSR<vertex_type, edge_type, value_type>>(result, &cpu_context, true);
+auto csr = coo->Convert<sparsebase::format::CSR>(&cpu_context, true);
 
 ```
 

--- a/examples/array_example/array_example.cu
+++ b/examples/array_example/array_example.cu
@@ -30,17 +30,14 @@ int main() {
 
   format::Array<int> *array = new format::Array<int>(6, vals);
 
-  auto converter = new utils::converter::ConverterOrderOne<int>();
 
-  auto cuda_array =
-      converter->Convert<format::cuda::CUDAArray<int>>(array, &gpu_context);
+  auto cuda_array = array->Convert<format::cuda::CUDAArray>(&gpu_context);
 
   print_array_cuda<<<1, 1>>>(cuda_array->get_vals(),
                              cuda_array->get_dimensions()[0]);
   cudaDeviceSynchronize();
 
-  auto cpu_array =
-      converter->Convert<format::Array<int>>(cuda_array, &cpu_context);
+  auto cpu_array->Convert<format::Array>(&cpu_context);
 
   print_array(cpu_array->get_vals(), cuda_array->get_dimensions()[0]);
 

--- a/examples/format_conversion/format_conversion.cc
+++ b/examples/format_conversion/format_conversion.cc
@@ -16,10 +16,8 @@ int main() {
   context::CPUContext cpu_context;
   format::COO<int, int, int> *coo =
       new format::COO<int, int, int>(6, 6, 6, row, col, vals);
-  auto converter = new utils::converter::ConverterOrderTwo<int, int, int>();
-  auto csr = converter->Convert(
-      coo, format::CSR<int, int, int>::get_format_id_static(), &cpu_context);
-  auto csr2 = csr->As<format::CSR<int, int, int>>();
+  auto csr = coo->Convert<format::CSR>(&cpu_context);
+  auto csr2 = csr->Convert<format::CSR>(&cpu_context);
 
   auto dims = csr2->get_dimensions();
   int n = dims[0];
@@ -43,8 +41,7 @@ int main() {
   cout << endl;
 
   // Conversion Syntax 2
-  auto coo2 =
-      converter->Convert<format::COO<int, int, int>>(csr2, &cpu_context);
+  auto coo2 = csr2->Convert<format::COO>(&cpu_context);
   cout << "COO" << endl;
 
   for (int i = 0; i < nnz; i++)
@@ -60,6 +57,5 @@ int main() {
   cout << endl;
 
   delete coo;
-  delete converter;
   delete csr2;
 }

--- a/src/sparsebase/format/cuda/format.cuh
+++ b/src/sparsebase/format/cuda/format.cuh
@@ -23,7 +23,7 @@ template <typename T> struct CUDADeleter {
 
 template <typename IDType, typename NNZType, typename ValueType>
 class CUDACSR
-    : public FormatImplementation<CUDACSR<IDType, NNZType, ValueType>> {
+    : public FormatImplementation<CUDACSR<IDType, NNZType, ValueType>, FormatOrderTwo<IDType, NNZType, ValueType>> {
 public:
   CUDACSR(IDType n, IDType m, NNZType nnz, NNZType *row_ptr, IDType *col,
           ValueType *vals, context::cuda::CUDAContext context,
@@ -62,7 +62,7 @@ protected:
 };
 
 template <typename ValueType>
-class CUDAArray : public FormatImplementation<CUDAArray<ValueType>> {
+class CUDAArray : public FormatImplementation<CUDAArray<ValueType>, FormatOrderOne<ValueType>> {
 public:
   CUDAArray(DimensionType nnz, ValueType *row_ptr,
             context::cuda::CUDAContext context, Ownership own = kNotOwned);

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -169,7 +169,7 @@ class FormatOrderOne : public FormatImplementation<FormatOrderOne<ValueType>, Fo
    * object and return a pointer to the new object.
    */
     template <template <typename> typename ToType>
-    ToType<ValueType> *Convert(context::Context *to_context,
+    ToType<ValueType> *Convert(context::Context *to_context=nullptr,
                                bool is_move_conversion = false);
 };
 template <typename IDType, typename NNZType, typename ValueType>
@@ -187,7 +187,7 @@ class FormatOrderTwo
    */
     template <template <typename, typename, typename> class ToType>
     ToType<IDType, NNZType, ValueType> *
-    Convert(context::Context *to_context, bool is_move_conversion = false);
+    Convert(context::Context *to_context=nullptr, bool is_move_conversion = false);
 };
 
 //! Coordinate List Sparse Data Format
@@ -380,8 +380,10 @@ ToType<ValueType> *sparsebase::format::FormatOrderOne<ValueType>::Convert(
                                 ToType<ValueType>>::value,
                 "T must be a format::Format");
   sparsebase::utils::converter::ConverterOrderOne<ValueType> converter;
+  context::Context *actual_context =
+      to_context == nullptr ?  this->get_context() : to_context;
   return converter
-      .Convert(this, ToType<ValueType>::get_format_id_static(), to_context,
+      .Convert(this, ToType<ValueType>::get_format_id_static(), actual_context,
                is_move_conversion)
       ->template As<ToType<ValueType>>();
 }
@@ -397,9 +399,11 @@ FormatOrderTwo<IDType, NNZType, ValueType>::Convert(
       "T must be an order two format");
   sparsebase::utils::converter::ConverterOrderTwo<IDType, NNZType, ValueType>
       converter;
+  context::Context* actual_context =
+      to_context == nullptr ?  this->get_context() : to_context;
   return converter
       .Convert(this, ToType<IDType, NNZType, ValueType>::get_format_id_static(),
-               to_context, is_move_conversion)
+               actual_context, is_move_conversion)
       ->template As<ToType<IDType, NNZType, ValueType>>();
 }
 

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -331,7 +331,7 @@ protected:
  * in Algorithms and Architectures. CiteSeerX 10.1.1.211.5256.
  */
 template <typename IDType, typename NNZType, typename ValueType>
-class CSC : public FormatImplementation<CSC<IDType, NNZType, ValueType>> {
+class CSC : public FormatImplementation<CSC<IDType, NNZType, ValueType>, FormatOrderTwo<IDType, NNZType, ValueType>> {
 public:
   CSC(IDType n, IDType m, NNZType *col_ptr, IDType *col, ValueType *vals,
       Ownership own = kNotOwned, bool ignore_sort = false);

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -160,20 +160,34 @@ protected:
 template <typename ValueType>
 class FormatOrderOne : public FormatImplementation<FormatOrderOne<ValueType>, Format> {
   public:
-  template <template <typename> typename ToType>
-  ToType<ValueType> *Convert(
-                             context::Context *to_context,
-                             bool is_move_conversion = false);
+  //! Converts `this` to a FormatOrderOne object of type ToType<ValueType>
+  /*!
+   * \param to_context context used to carry out the conversion.
+   * \param is_move_conversion whether to carry out a move conversion.
+   * \return If `this` is of type `ToType<ValueType>` then it returns the same object
+   * but as a different type. If not, it will convert `this` to a new FormatOrderOne 
+   * object and return a pointer to the new object.
+   */
+    template <template <typename> typename ToType>
+    ToType<ValueType> *Convert(context::Context *to_context,
+                               bool is_move_conversion = false);
 };
 template <typename IDType, typename NNZType, typename ValueType>
 class FormatOrderTwo
     : public FormatImplementation<FormatOrderTwo<IDType, NNZType, ValueType>,
                                   Format> {
   public:
-  template <template <typename, typename, typename> class ToType>
-  ToType<IDType, NNZType, ValueType> *Convert(
-                                              context::Context *to_context,
-                                              bool is_move_conversion = false);
+  //! Converts `this` to a FormatOrderTwo object of type ToType<IDType, NNZType, ValueType>
+  /*!
+   * \param to_context context used to carry out the conversion.
+   * \param is_move_conversion whether to carry out a move conversion.
+   * \return If `this` is of type `ToType<ValueType>` then it returns the same object
+   * but as a different type. If not, it will convert `this` to a new FormatOrderOne 
+   * object and return a pointer to the new object.
+   */
+    template <template <typename, typename, typename> class ToType>
+    ToType<IDType, NNZType, ValueType> *
+    Convert(context::Context *to_context, bool is_move_conversion = false);
 };
 
 //! Coordinate List Sparse Data Format
@@ -303,15 +317,16 @@ protected:
 } // namespace format
 
 } // namespace sparsebase
+
 #include "sparsebase/utils/converter/converter.h"
 
 namespace sparsebase {
 namespace format {
+
 template <typename ValueType>
 template <template <typename> class ToType>
 ToType<ValueType> *sparsebase::format::FormatOrderOne<ValueType>::Convert(
-    context::Context *to_context,
-    bool is_move_conversion) {
+    context::Context *to_context, bool is_move_conversion) {
   static_assert(std::is_base_of<format::FormatOrderOne<ValueType>,
                                 ToType<ValueType>>::value,
                 "T must be a format::Format");
@@ -326,8 +341,7 @@ template <typename IDType, typename NNZType, typename ValueType>
 template <template <typename, typename, typename> class ToType>
 ToType<IDType, NNZType, ValueType> *
 FormatOrderTwo<IDType, NNZType, ValueType>::Convert(
-    context::Context *to_context,
-    bool is_move_conversion) {
+    context::Context *to_context, bool is_move_conversion) {
   static_assert(
       std::is_base_of<format::FormatOrderTwo<IDType, NNZType, ValueType>,
                       ToType<IDType, NNZType, ValueType>>::value,
@@ -335,12 +349,13 @@ FormatOrderTwo<IDType, NNZType, ValueType>::Convert(
   sparsebase::utils::converter::ConverterOrderTwo<IDType, NNZType, ValueType>
       converter;
   return converter
-      .Convert(this,
-               ToType<IDType, NNZType, ValueType>::get_format_id_static(),
+      .Convert(this, ToType<IDType, NNZType, ValueType>::get_format_id_static(),
                to_context, is_move_conversion)
       ->template As<ToType<IDType, NNZType, ValueType>>();
 }
+
 } // namespace format
+
 } // namespace sparsebase
 #ifdef _HEADER_ONLY
 #include "sparsebase/format/format.cc"

--- a/src/sparsebase/utils/converter/converter.h
+++ b/src/sparsebase/utils/converter/converter.h
@@ -10,7 +10,6 @@
 #define SPARSEBASE_SPARSEBASE_UTILS_CONVERTER_CONVERTER_H_
 
 #include "sparsebase/config.h"
-#include "sparsebase/format/format.h"
 #include <functional>
 #include <tuple>
 #include <unordered_map>
@@ -19,6 +18,22 @@
 #include "sparsebase/utils/converter/cuda/converter.cuh"
 #endif
 
+namespace sparsebase {
+namespace utils {
+namespace converter {
+class Converter;
+template <class ConverterType> 
+class ConverterImpl;
+template <typename IDType, typename NNZType, typename ValueType>
+class ConverterOrderTwo;
+template <typename ValueType>
+class ConverterOrderOne;
+    
+} // namespace converter
+} // namespace utils
+} // namespace sparsebase
+
+#include "sparsebase/format/format.h"
 namespace sparsebase {
 
 namespace utils {
@@ -171,43 +186,6 @@ public:
   virtual void Reset();
 };
 
-template <typename T>
-struct type_unwrapper;
-
-template <template <typename...> class C, typename... Ts>
-struct type_unwrapper<C<Ts...>>
-{
-    static constexpr std::size_t type_count = sizeof...(Ts);
-
-    template <std::size_t N>
-    using param_t = typename std::tuple_element<N, std::tuple<Ts...>>::type;
-};
-
-template < template <typename, typename, typename> class ToType, typename IDType, typename NNZType, typename ValueType>
-ToType<IDType, NNZType, ValueType>*
-ConvertOrderTwo(format::Format *source,
-        context::Context *to_context, bool is_move_conversion = false) {
-  static_assert(std::is_base_of<format::Format, ToType<IDType, NNZType, ValueType>>::value,
-                "T must be a format::Format");
-  ConverterOrderTwo<IDType, NNZType, ValueType> converter;
-  auto f = converter.Convert(
-      source, ToType<IDType, NNZType, ValueType>::get_format_id_static(),
-      to_context, is_move_conversion);
-  return static_cast<ToType<IDType, NNZType, ValueType>*>(f);
-}
-
-template < template <typename> class ToType, typename ValueType>
-ToType<ValueType>*
-ConvertOrderOne(format::Format *source,
-        context::Context *to_context, bool is_move_conversion = false) {
-  static_assert(std::is_base_of<format::Format, ToType<ValueType>>::value,
-                "T must be a format::Format");
-  ConverterOrderOne<ValueType> converter;
-  auto f = converter.Convert(
-      source, ToType<ValueType>::get_format_id_static(),
-      to_context, is_move_conversion);
-  return static_cast<ToType<ValueType>*>(f);
-}
 
 
 } // namespace converter

--- a/src/sparsebase/utils/converter/converter.h
+++ b/src/sparsebase/utils/converter/converter.h
@@ -186,8 +186,6 @@ public:
   virtual void Reset();
 };
 
-
-
 } // namespace converter
 
 } // namespace utils

--- a/src/sparsebase/utils/converter/converter.h
+++ b/src/sparsebase/utils/converter/converter.h
@@ -18,6 +18,7 @@
 #include "sparsebase/utils/converter/cuda/converter.cuh"
 #endif
 
+// Forward declerations for the `Convert` functions in sparsebase/format/format.h
 namespace sparsebase {
 namespace utils {
 namespace converter {

--- a/tests/suites/sparsebase/format/format_tests.cc
+++ b/tests/suites/sparsebase/format/format_tests.cc
@@ -50,6 +50,69 @@ TEST(COO, Basics) {
   }
 }
 
+TEST(FormatOrderTwo, ConvertSameFormat) {
+  // Construct the CSR
+  sparsebase::format::CSR<int, int, int> csr(4, 4, csr_row_ptr, csr_col,
+                                             csr_vals);
+
+  sparsebase::context::CPUContext cpu_context;
+  sparsebase::format::CSR<int, int, int>* csr_converted = csr.Convert<sparsebase::format::CSR>(&cpu_context);
+  EXPECT_EQ(csr_converted, &csr);
+  // Check the dimensions
+  EXPECT_EQ(csr_converted->get_num_nnz(), 4);
+  std::vector<sparsebase::format::DimensionType> expected_dimensions{4, 4};
+  EXPECT_EQ(csr_converted->get_dimensions(), expected_dimensions);
+
+  // Check the arrays
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(csr_converted->get_col()[i], csr_col[i]);
+    EXPECT_EQ(csr_converted->get_vals()[i], csr_vals[i]);
+  }
+
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr_converted->get_row_ptr()[i], csr_row_ptr[i]);
+  }
+}
+
+TEST(FormatOrderTwo, ConvertDifferentFormat) {
+  // Construct the CSR
+  sparsebase::format::CSR<int, int, int> csr(4, 4, csr_row_ptr, csr_col,
+                                             csr_vals);
+
+  sparsebase::context::CPUContext cpu_context;
+  sparsebase::format::COO<int, int, int>* coo_converted = csr.Convert<sparsebase::format::COO>(&cpu_context);
+  // Check the dimensions
+  EXPECT_EQ(coo_converted->get_num_nnz(), 4);
+  std::vector<sparsebase::format::DimensionType> expected_dimensions{4, 4};
+  EXPECT_EQ(coo_converted->get_dimensions(), expected_dimensions);
+
+  // Check the arrays
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(coo_converted->get_row()[i], coo_row[i]);
+    EXPECT_EQ(coo_converted->get_col()[i], coo_col[i]);
+    EXPECT_EQ(coo_converted->get_vals()[i], coo_vals[i]);
+  }
+}
+
+TEST(FormatOrderOne, Convert) {
+  sparsebase::format::Array<int> array(4, coo_vals,
+                                       sparsebase::format::kNotOwned);
+
+  sparsebase::context::CPUContext cpu_context;
+  sparsebase::format::Array<int>* conv_arr = array.Convert<sparsebase::format::Array>(&cpu_context);
+  EXPECT_EQ(conv_arr, &array);
+  // Check the dimensions
+  EXPECT_EQ(conv_arr->get_num_nnz(), 4);
+  std::vector<sparsebase::format::DimensionType> expected_dimensions{4};
+  EXPECT_EQ(conv_arr->get_dimensions(), expected_dimensions);
+
+  // Check the array
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(conv_arr->get_vals()[i], coo_vals[i]);
+  }
+}
+
+
 TEST(Array, Basics) {
   sparsebase::format::Array<int> array(4, coo_vals,
                                        sparsebase::format::kNotOwned);


### PR DESCRIPTION
Applied the changes described in #133 which includes:

1. The format type classes `FormatOrderOne` and `FormatOrderTwo`.
2. The `Convert` functions inside these classes.
3. Tests for the `Convert` function.
4. Changed the documentation's Getting Started page to use this function instead of the Converter object.