### PR TITLE
Adding IOBase 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,8 @@ set(PREPROCESS_FILES
 set(OBJECT_FILES 
   sparsebase/object/object.h
 )
-set(IO_FILES 
+set(IO_FILES
+  sparsebase/utils/io/iobase.h
   sparsebase/utils/io/reader.h
   sparsebase/utils/io/sparse_file_format.h
   sparsebase/utils/io/writer.h

--- a/src/sparsebase/sparsebase.h
+++ b/src/sparsebase/sparsebase.h
@@ -16,6 +16,7 @@
 #include "sparsebase/utils/converter/converter.h"
 #include "sparsebase/utils/exception.h"
 #include "sparsebase/utils/io/reader.h"
+#include "sparsebase/utils/io/iobase.h"
 #include "sparsebase/utils/io/writer.h"
 #ifdef CUDA
 #include "sparsebase/context/cuda/context.cuh"

--- a/src/sparsebase/utils/io/iobase.h
+++ b/src/sparsebase/utils/io/iobase.h
@@ -37,6 +37,72 @@ public:
   static format::Array<ValueType> * ReadMTXToArray(std::string filename, bool convert_index_to_zero=true){
     MTXReader<IDType, NNZType, ValueType> reader(filename, convert_index_to_zero);
     return reader.ReadArray();
+ }
+ // PIGO
+
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::CSR<IDType, NNZType, ValueType> * ReadPigoMTXToCSR(std::string filename, bool weighted, bool convert_index_to_zero=true){
+    PigoMTXReader<IDType, NNZType, ValueType> reader(filename, weighted, convert_index_to_zero);
+    return reader.ReadCSR();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::COO<IDType, NNZType, ValueType> * ReadPigoMTXToCOO(std::string filename, bool weighted, bool convert_index_to_zero=true){
+    PigoMTXReader<IDType, NNZType, ValueType> reader(filename, weighted, convert_index_to_zero);
+    return reader.ReadCOO();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::CSR<IDType, NNZType, ValueType> * ReadPigoEdgeListToCSR(std::string filename, bool weighted){
+    PigoEdgeListReader<IDType, NNZType, ValueType> reader(filename, weighted);
+    return reader.ReadCSR();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::COO<IDType, NNZType, ValueType> * ReadPigoEdgeListToCOO(std::string filename, bool weighted){
+    PigoEdgeListReader<IDType, NNZType, ValueType> reader(filename, weighted);
+    return reader.ReadCOO();
+  }
+
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::CSR<IDType, NNZType, ValueType> * ReadEdgeListToCSR(std::string filename, bool weighted = false, bool remove_self_edges = false, bool read_undirected = true, bool square = false){
+    EdgeListReader<IDType, NNZType, ValueType> reader(filename, weighted, true, remove_self_edges, read_undirected, square);
+    return reader.ReadCSR();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::COO<IDType, NNZType, ValueType> * ReadEdgeListToCOO(std::string filename, bool weighted = false, bool remove_self_edges = false, bool read_undirected = true, bool square = false){
+    EdgeListReader<IDType, NNZType, ValueType> reader(filename, weighted, true, remove_self_edges, read_undirected, square);
+    return reader.ReadCOO();
+  }
+
+  // Binary reader
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::CSR<IDType, NNZType, ValueType> * ReadBinaryToCSR(std::string filename){
+    BinaryReaderOrderTwo<IDType, NNZType, ValueType> reader(filename);
+    return reader.ReadCSR();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::COO<IDType, NNZType, ValueType> * ReadBinaryToCOO(std::string filename){
+    BinaryReaderOrderTwo<IDType, NNZType, ValueType> reader(filename);
+    return reader.ReadCOO();
+  }
+  template <typename ValueType>
+  static format::Array<ValueType> * ReadBinaryToArray(std::string filename){
+    BinaryReaderOrderOne<ValueType> reader(filename);
+    return reader.ReadArray();
+  }
+
+  template <typename IDType, typename NNZType, typename ValueType>
+  static void WriteCOOToBinary(format::COO<IDType, NNZType, ValueType>* coo, std::string filename){
+    BinaryWriterOrderTwo<IDType, NNZType, ValueType> writer(filename);
+    return writer.WriteCOO(coo);
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static void WriteCSRToBinary(format::CSR<IDType, NNZType, ValueType>* csr, std::string filename){
+    BinaryWriterOrderTwo<IDType, NNZType, ValueType> writer(filename);
+    return writer.WriteCSR(csr);
+  }
+  template <typename ValueType>
+  static void WriteArrayToBinary(format::Array<ValueType>* array, std::string filename){
+    BinaryWriterOrderOne<ValueType> writer(filename);
+    return writer.WriteArray(array);
   }
 };
 }

--- a/src/sparsebase/utils/io/iobase.h
+++ b/src/sparsebase/utils/io/iobase.h
@@ -1,0 +1,45 @@
+//
+// Created by Amro on 9/14/2022.
+//
+
+#ifndef SPARSEBASE_PROJECT_IOBASE_H
+#define SPARSEBASE_PROJECT_IOBASE_H
+
+#include "sparsebase/config.h"
+#include "sparsebase/format/format.h"
+#include "sparsebase/utils/io/reader.h"
+#include "sparsebase/utils/io/writer.h"
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace sparsebase;
+namespace sparsebase{
+
+namespace utils {
+namespace io {
+class IOBase {
+public:
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::CSR<IDType, NNZType, ValueType> * ReadMTXToCSR(std::string filename, bool convert_index_to_zero=true){
+    MTXReader<IDType, NNZType, ValueType> reader(filename, convert_index_to_zero);
+    return reader.ReadCSR();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::COO<IDType, NNZType, ValueType> * ReadMTXToCOO(std::string filename, bool convert_index_to_zero=true){
+    MTXReader<IDType, NNZType, ValueType> reader(filename, convert_index_to_zero);
+    return reader.ReadCOO();
+  }
+  template <typename IDType, typename NNZType, typename ValueType>
+  static format::Array<ValueType> * ReadMTXToArray(std::string filename, bool convert_index_to_zero=true){
+    MTXReader<IDType, NNZType, ValueType> reader(filename, convert_index_to_zero);
+    return reader.ReadArray();
+  }
+};
+}
+}
+}
+#endif // SPARSEBASE_PROJECT_IOBASE_H

--- a/src/sparsebase/utils/io/reader.cc
+++ b/src/sparsebase/utils/io/reader.cc
@@ -554,12 +554,12 @@ PigoMTXReader<IDType, NNZType, ValueType>::PigoMTXReader(
     : filename_(filename), weighted_(weighted),
       convert_to_zero_index_(convert_to_zero_index) {}
 
-template <typename IDType, typename NNZType, typename ValueType>
-format::Array<ValueType> *
-PigoMTXReader<IDType, NNZType, ValueType>::ReadArray() const {
-  MTXReader<IDType, NNZType, ValueType> reader(filename_, weighted_);
-  return reader.ReadArray();
-}
+//template <typename IDType, typename NNZType, typename ValueType>
+//format::Array<ValueType> *
+//PigoMTXReader<IDType, NNZType, ValueType>::ReadArray() const {
+//  MTXReader<IDType, NNZType, ValueType> reader(filename_, weighted_);
+//  return reader.ReadArray();
+//}
 
 template <typename IDType, typename NNZType, typename ValueType>
 format::COO<IDType, NNZType, ValueType> *

--- a/src/sparsebase/utils/io/reader.cc
+++ b/src/sparsebase/utils/io/reader.cc
@@ -575,7 +575,6 @@ PigoMTXReader<IDType, NNZType, ValueType>::ReadCOO() const {
     coo = new format::COO<IDType, NNZType, ValueType>(
         pigo_coo.nrows() - 1, pigo_coo.ncols() - 1, pigo_coo.m(), pigo_coo.x(),
         pigo_coo.y(), pigo_coo.w(), format::kOwned);
-    std::cout << " x y z " << pigo_coo.x() << " " <<pigo_coo.y() << " " << pigo_coo.w() << std::endl;
   } else {
     pigo::COO<IDType, IDType, IDType *, false, false, false, false, ValueType,
               ValueType *>
@@ -583,7 +582,6 @@ PigoMTXReader<IDType, NNZType, ValueType>::ReadCOO() const {
     coo = new format::COO<IDType, NNZType, ValueType>(
         pigo_coo.nrows() - 1, pigo_coo.ncols() - 1, pigo_coo.m(), pigo_coo.x(),
         pigo_coo.y(), nullptr, format::kOwned);
-    std::cout << " x y z " << pigo_coo.x() << " " <<pigo_coo.y() << " " << pigo_coo.w() << std::endl;
   }
 
   if (convert_to_zero_index_) {

--- a/src/sparsebase/utils/io/reader.cc
+++ b/src/sparsebase/utils/io/reader.cc
@@ -575,6 +575,7 @@ PigoMTXReader<IDType, NNZType, ValueType>::ReadCOO() const {
     coo = new format::COO<IDType, NNZType, ValueType>(
         pigo_coo.nrows() - 1, pigo_coo.ncols() - 1, pigo_coo.m(), pigo_coo.x(),
         pigo_coo.y(), pigo_coo.w(), format::kOwned);
+    std::cout << " x y z " << pigo_coo.x() << " " <<pigo_coo.y() << " " << pigo_coo.w() << std::endl;
   } else {
     pigo::COO<IDType, IDType, IDType *, false, false, false, false, ValueType,
               ValueType *>
@@ -582,6 +583,7 @@ PigoMTXReader<IDType, NNZType, ValueType>::ReadCOO() const {
     coo = new format::COO<IDType, NNZType, ValueType>(
         pigo_coo.nrows() - 1, pigo_coo.ncols() - 1, pigo_coo.m(), pigo_coo.x(),
         pigo_coo.y(), nullptr, format::kOwned);
+    std::cout << " x y z " << pigo_coo.x() << " " <<pigo_coo.y() << " " << pigo_coo.w() << std::endl;
   }
 
   if (convert_to_zero_index_) {
@@ -641,7 +643,7 @@ PigoEdgeListReader<IDType, NNZType, ValueType>::ReadCOO() const {
               ValueType *>
         coo(filename_, pigo::EDGE_LIST);
     return new format::COO<IDType, NNZType, ValueType>(
-        coo.nrows(), coo.ncols(), coo.m(), coo.x(), coo.y(), coo.w(),
+        coo.nrows(), coo.ncols(), coo.m(), coo.x(), coo.y(), nullptr,
         format::kOwned);
   }
 #else

--- a/src/sparsebase/utils/io/reader.cc
+++ b/src/sparsebase/utils/io/reader.cc
@@ -581,7 +581,7 @@ PigoMTXReader<IDType, NNZType, ValueType>::ReadCOO() const {
         pigo_coo(filename_, pigo::MATRIX_MARKET);
     coo = new format::COO<IDType, NNZType, ValueType>(
         pigo_coo.nrows() - 1, pigo_coo.ncols() - 1, pigo_coo.m(), pigo_coo.x(),
-        pigo_coo.y(), pigo_coo.w(), format::kOwned);
+        pigo_coo.y(), nullptr, format::kOwned);
   }
 
   if (convert_to_zero_index_) {
@@ -611,6 +611,7 @@ format::CSR<IDType, NNZType, ValueType> *
 PigoMTXReader<IDType, NNZType, ValueType>::ReadCSR() const {
   format::COO<IDType, NNZType, ValueType> *coo = ReadCOO();
   utils::converter::ConverterOrderTwo<IDType, NNZType, ValueType> converter;
+  std::cout << "nnz " << coo->get_num_nnz() << " dim " << coo->get_dimensions()[0] << " " << coo->get_dimensions()[1] << std::endl;
   return converter.template Convert<format::CSR<IDType, NNZType, ValueType>>(
       coo, coo->get_context(), true);
 }

--- a/src/sparsebase/utils/io/reader.h
+++ b/src/sparsebase/utils/io/reader.h
@@ -168,14 +168,13 @@ private:
 template <typename IDType, typename NNZType, typename ValueType>
 class PigoMTXReader : public Reader,
                       public ReadsCOO<IDType, NNZType, ValueType>,
-                      public ReadsCSR<IDType, NNZType, ValueType>,
-                      public ReadsArray<ValueType> {
+                      public ReadsCSR<IDType, NNZType, ValueType> {
 public:
   PigoMTXReader(std::string filename, bool weighted,
                 bool convert_to_zero_index = true);
   format::COO<IDType, NNZType, ValueType> *ReadCOO() const override;
   format::CSR<IDType, NNZType, ValueType> *ReadCSR() const override;
-  format::Array<ValueType> *ReadArray() const override;
+  //format::Array<ValueType> *ReadArray() const override;
   virtual ~PigoMTXReader() = default;
 
 private:

--- a/tests/suites/sparsebase/utils/io/reader_tests.cc
+++ b/tests/suites/sparsebase/utils/io/reader_tests.cc
@@ -289,7 +289,7 @@ TEST(IOBase, ReadBinaryToArray) {
   }
 }
 
-TEST(IOBase, ReadPigoMTXReadToCSR) {
+TEST(IOBase, ReadPigoMTXToCSR) {
   // Write the mtx data to a file
   std::ofstream ofs("test_pigo.mtx");
   ofs << mtx_data;
@@ -1013,6 +1013,63 @@ TEST(EdgeListReader, Basics) {
     EXPECT_EQ(coo3->get_row()[i], row[i]);
     EXPECT_EQ(coo3->get_col()[i], col[i]);
     EXPECT_EQ(coo3->get_vals()[i], vals[i]);
+  }
+}
+TEST(PigoMTXReader, CSR) {
+  // Write the mtx data to a file
+  std::ofstream ofs("test_pigo.mtx");
+  ofs << mtx_data;
+  ofs.close();
+
+  // Write the mtx data with values to a file
+  std::ofstream ofs2("test_values_pigo.mtx");
+  ofs2 << mtx_data_with_values;
+  ofs2.close();
+
+  sparsebase::utils::io::PigoMTXReader<int, int, int> reader("test_pigo.mtx",
+                                                             false);
+  auto csr = reader.ReadCSR();
+
+  // Check the dimensions
+  EXPECT_EQ(csr->get_dimensions()[0], 5);
+  EXPECT_EQ(csr->get_dimensions()[1], 5);
+  EXPECT_EQ(csr->get_num_nnz(), 5);
+
+  // Check that the arrays are populated
+  EXPECT_NE(csr->get_row_ptr(), nullptr);
+  EXPECT_NE(csr->get_col(), nullptr);
+
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr->get_col()[i], col[i]);
+  }
+
+  sparsebase::utils::io::PigoMTXReader<int, int, float> reader2(
+      "test_values_pigo.mtx", true);
+  auto csr2 = reader2.ReadCSR();
+
+  // Check the dimensions
+  EXPECT_EQ(csr2->get_dimensions()[0], 5);
+  EXPECT_EQ(csr2->get_dimensions()[1], 5);
+  EXPECT_EQ(csr2->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(csr2->get_vals(), nullptr);
+  EXPECT_NE(csr2->get_row_ptr(), nullptr);
+  EXPECT_NE(csr2->get_col(), nullptr);
+
+
+  for (int i = 0; i < 5; i++) {
+  EXPECT_EQ(csr2->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr2->get_col()[i], col[i]);
+    EXPECT_EQ(csr2->get_vals()[i], vals[i]);
   }
 }
 

--- a/tests/suites/sparsebase/utils/io/reader_tests.cc
+++ b/tests/suites/sparsebase/utils/io/reader_tests.cc
@@ -21,11 +21,11 @@ const std::string mtx_symm_data =
 %This is a comment
 5 5 6
 1 1
-2 1 
-4 1 
-3 2 
-5 3 
-5 4 
+2 1
+4 1
+3 2
+5 3
+5 4
 )";
 
 const std::string mtx_data_with_values =
@@ -205,6 +205,57 @@ void checkArrayReading(std::string filename){
   EXPECT_EQ(array->get_dimensions()[0], one_row_one_col_length);
   EXPECT_EQ(array->get_num_nnz(), one_row_one_col_length);
 
+TEST(IOBase, Basics) {
+
+  // Write the mtx data to a file
+  std::ofstream ofs("test.mtx");
+  ofs << mtx_data;
+  ofs.close();
+
+  // Write the mtx data with values to a file
+  std::ofstream ofs2("test_values.mtx");
+  ofs2 << mtx_data_with_values;
+  ofs2.close();
+
+  // Read non-weighted file using sparsebase
+  auto coo = sparsebase::utils::io::IOBase::ReadMTXToCOO<int, int, int>("test.mtx", false);
+
+  // Check the dimensions
+  EXPECT_EQ(coo->get_dimensions()[0], 5);
+  EXPECT_EQ(coo->get_dimensions()[1], 5);
+  EXPECT_EQ(coo->get_num_nnz(), 5);
+
+  // Check that the arrays are populated
+  EXPECT_NE(coo->get_row(), nullptr);
+  EXPECT_NE(coo->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo->get_row()[i], row[i]);
+    EXPECT_EQ(coo->get_col()[i], col[i]);
+  }
+
+  // Read the weighted file using sparsebase
+  auto coo2 = sparsebase::utils::io::IOBase::ReadMTXToCOO<int, int, int>("test_values.mtx", true);
+
+  // Check the dimensions
+  EXPECT_EQ(coo2->get_dimensions()[0], 5);
+  EXPECT_EQ(coo2->get_dimensions()[1], 5);
+  EXPECT_EQ(coo2->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(coo2->get_vals(), nullptr);
+  EXPECT_NE(coo2->get_row(), nullptr);
+  EXPECT_NE(coo2->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo2->get_row()[i], row[i]);
+    EXPECT_EQ(coo2->get_col()[i], col[i]);
+    EXPECT_EQ(coo2->get_vals()[i], vals[i]);
+  }
+}
+TEST(MTXReader, Basics) {
   // Check that the arrays are populated
   EXPECT_NE(array->get_vals(), nullptr);
   for (int i= 0; i< 10; i++) std::cout << array->get_vals()[i] <<" ";

--- a/tests/suites/sparsebase/utils/io/reader_tests.cc
+++ b/tests/suites/sparsebase/utils/io/reader_tests.cc
@@ -184,6 +184,7 @@ const std::string edge_list_data_with_values = R"(1 0 0.1
 
 // Both files should result in the COO arrays below
 // (With the convert_to_zero_index option set to true for mtx)
+int row_ptr[6]{0, 0, 1, 2, 3,  5};
 int row[5]{1, 2, 3, 4, 4};
 int col[5]{0, 1, 0, 2, 3};
 int one_row_one_col[5]{1, 3, 4, 5, 8};
@@ -195,7 +196,7 @@ int row_symm[11]   {0,   0,   0,   1,   1,   2,   2,   3,   3,   4,   4};
 int col_symm[11]   {0,   1,   3,   0,   2,   1,   4,   0,   4,   2,   3};
 float vals_symm[11]{0.7, 0.1, 0.2, 0.1, 0.3, 0.3, 0.4, 0.2, 0.5, 0.4, 0.5};
 
-void checkArrayReading(std::string filename){
+void checkArrayReading(std::string filename) {
 
   // Read one column file
   sparsebase::utils::io::MTXReader<int, int, float> reader(filename, true);
@@ -204,21 +205,157 @@ void checkArrayReading(std::string filename){
   // Check the dimensions
   EXPECT_EQ(array->get_dimensions()[0], one_row_one_col_length);
   EXPECT_EQ(array->get_num_nnz(), one_row_one_col_length);
+}
 
-TEST(IOBase, Basics) {
+TEST(IOBase, ReadBinaryToCOO) {
 
+  // Initialize a COO for testing
+  int row[4]{1, 2, 3, 4};
+  int col[4]{5, 6, 7, 8};
+  float vals[4]{0.1, 0.2, 0.3, 0.4};
+  sparsebase::format::COO<int, int, float> coo(4, 4, 4, row, col, vals,
+                                               sparsebase::format::kNotOwned);
+
+  // Write the COO to a binary file with sparsebase
+  sparsebase::utils::io::BinaryWriterOrderTwo<int, int, float> writerOrderTwo(
+      "reader_test_order_two_coo.bin");
+  writerOrderTwo.WriteCOO(&coo);
+
+  // Read the COO from the binary file with sparsebase
+  auto coo2 = utils::io::IOBase::ReadBinaryToCOO<int, int, float>("reader_test_order_two_coo.bin");
+
+  // Compare the dimensions
+  EXPECT_EQ(coo.get_dimensions(), coo2->get_dimensions());
+  EXPECT_EQ(coo.get_num_nnz(), coo2->get_num_nnz());
+
+  // Compare the underlying arrays
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(coo.get_row()[i], coo2->get_row()[i]);
+    EXPECT_EQ(coo.get_col()[i], coo2->get_col()[i]);
+    EXPECT_EQ(coo.get_vals()[i], coo2->get_vals()[i]);
+  }
+}
+
+TEST(IOBase, ReadBinaryToCSR) {
+  // Initialize a CSR for testing
+  int row_ptr[5]{0, 2, 3, 3, 4};
+  int col[4]{0, 2, 1, 3};
+  float vals[4]{0.1, 0.2, 0.3, 0.4};
+
+  sparsebase::format::CSR<int, int, float> csr(4, 4, row_ptr, col, vals,
+                                               sparsebase::format::kNotOwned);
+
+  // Write the COO to a binary file with sparsebase
+  sparsebase::utils::io::BinaryWriterOrderTwo<int, int, float> writerOrderTwo(
+      "reader_test_order_two_csr.bin");
+  writerOrderTwo.WriteCSR(&csr);
+
+  // Read the COO from the binary file with sparsebase
+  auto csr2 = utils::io::IOBase::ReadBinaryToCSR<int, int, float>("reader_test_order_two_csr.bin");
+
+  // Compare the dimensions
+  EXPECT_EQ(csr.get_dimensions(), csr2->get_dimensions());
+  EXPECT_EQ(csr.get_num_nnz(), csr2->get_num_nnz());
+
+  // Compare the underlying arrays
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(csr.get_col()[i], csr2->get_col()[i]);
+    EXPECT_EQ(csr.get_vals()[i], csr2->get_vals()[i]);
+  }
+
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr.get_row_ptr()[i], csr2->get_row_ptr()[i]);
+  }
+}
+TEST(IOBase, ReadBinaryToArray) {
+
+  // Initialize an array for testing
+  int array[5]{1, 2, 3, 4, 5};
+  sparsebase::format::Array<int> sbArray(5, array,
+                                         sparsebase::format::kNotOwned);
+
+  // Write the array to a binary file using sparsebase
+  sparsebase::utils::io::BinaryWriterOrderOne<int> writerOrderOne(
+      "test_order_one.bin");
+  writerOrderOne.WriteArray(&sbArray);
+
+  // Read the array from the binary file using sparsebase
+  auto array2 = utils::io::IOBase::ReadBinaryToArray<int>(
+      "test_order_one.bin");
+
+  // Compare the arrays
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(array[i], array2->get_vals()[i]);
+  }
+}
+
+TEST(IOBase, ReadPigoMTXReadToCSR) {
   // Write the mtx data to a file
-  std::ofstream ofs("test.mtx");
+  std::ofstream ofs("test_pigo.mtx");
   ofs << mtx_data;
   ofs.close();
 
   // Write the mtx data with values to a file
-  std::ofstream ofs2("test_values.mtx");
+  std::ofstream ofs2("test_values_pigo.mtx");
   ofs2 << mtx_data_with_values;
   ofs2.close();
 
-  // Read non-weighted file using sparsebase
-  auto coo = sparsebase::utils::io::IOBase::ReadMTXToCOO<int, int, int>("test.mtx", false);
+  auto csr = utils::io::IOBase::ReadPigoMTXToCSR<int, int, int>("test_pigo.mtx",
+                                                                false);
+
+  // Check the dimensions
+  EXPECT_EQ(csr->get_dimensions()[0], 5);
+  EXPECT_EQ(csr->get_dimensions()[1], 5);
+  EXPECT_EQ(csr->get_num_nnz(), 5);
+
+  // Check that the arrays are populated
+  EXPECT_NE(csr->get_row_ptr(), nullptr);
+  EXPECT_NE(csr->get_col(), nullptr);
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr->get_col()[i], col[i]);
+  }
+
+  auto csr2 = utils::io::IOBase::ReadPigoMTXToCSR<int, int, float>("test_values_pigo.mtx",
+                                                                   true);
+
+  // Check the dimensions
+  EXPECT_EQ(csr2->get_dimensions()[0], 5);
+  EXPECT_EQ(csr2->get_dimensions()[1], 5);
+  EXPECT_EQ(csr2->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(csr2->get_vals(), nullptr);
+  EXPECT_NE(csr2->get_row_ptr(), nullptr);
+  EXPECT_NE(csr2->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr2->get_row_ptr()[i], row_ptr[i]);
+  }
+
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr2->get_col()[i], col[i]);
+    EXPECT_EQ(csr2->get_vals()[i], vals[i]);
+  }
+}
+TEST(IOBase, ReadPigoMTXReadToCOO) {
+  // Write the mtx data to a file
+  std::ofstream ofs("test_pigo.mtx");
+  ofs << mtx_data;
+  ofs.close();
+
+  // Write the mtx data with values to a file
+  std::ofstream ofs2("test_values_pigo.mtx");
+  ofs2 << mtx_data_with_values;
+  ofs2.close();
+
+  auto coo = utils::io::IOBase::ReadPigoMTXToCOO<int, int, int>("test_pigo.mtx",
+                                                                false);
 
   // Check the dimensions
   EXPECT_EQ(coo->get_dimensions()[0], 5);
@@ -235,8 +372,8 @@ TEST(IOBase, Basics) {
     EXPECT_EQ(coo->get_col()[i], col[i]);
   }
 
-  // Read the weighted file using sparsebase
-  auto coo2 = sparsebase::utils::io::IOBase::ReadMTXToCOO<int, int, int>("test_values.mtx", true);
+  auto coo2 = utils::io::IOBase::ReadPigoMTXToCOO<int, int, float>("test_values_pigo.mtx",
+                                                                true);
 
   // Check the dimensions
   EXPECT_EQ(coo2->get_dimensions()[0], 5);
@@ -255,7 +392,340 @@ TEST(IOBase, Basics) {
     EXPECT_EQ(coo2->get_vals()[i], vals[i]);
   }
 }
-TEST(MTXReader, Basics) {
+TEST(IOBase, ReadMTXReadToCSR) {
+  // Write the mtx data to a file
+  std::ofstream ofs("test.mtx");
+  ofs << mtx_data;
+  ofs.close();
+
+  // Write the mtx data with values to a file
+  std::ofstream ofs2("test_values.mtx");
+  ofs2 << mtx_data_with_values;
+  ofs2.close();
+
+  auto csr = utils::io::IOBase::ReadMTXToCSR<int, int, int>("test_pigo.mtx",
+                                                                true);
+
+  // Check the dimensions
+  EXPECT_EQ(csr->get_dimensions()[0], 5);
+  EXPECT_EQ(csr->get_dimensions()[1], 5);
+  EXPECT_EQ(csr->get_num_nnz(), 5);
+
+  // Check that the arrays are populated
+  EXPECT_NE(csr->get_row_ptr(), nullptr);
+  EXPECT_NE(csr->get_col(), nullptr);
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr->get_col()[i], col[i]);
+  }
+
+  auto csr2 = utils::io::IOBase::ReadMTXToCSR<int, int, float>("test_values_pigo.mtx",
+                                                                   true);
+
+  // Check the dimensions
+  EXPECT_EQ(csr2->get_dimensions()[0], 5);
+  EXPECT_EQ(csr2->get_dimensions()[1], 5);
+  EXPECT_EQ(csr2->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(csr2->get_vals(), nullptr);
+  EXPECT_NE(csr2->get_row_ptr(), nullptr);
+  EXPECT_NE(csr2->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr2->get_row_ptr()[i], row_ptr[i]);
+  }
+
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr2->get_col()[i], col[i]);
+    EXPECT_EQ(csr2->get_vals()[i], vals[i]);
+  }
+}
+TEST(IOBase, ReadMTXReadToCOO) {
+
+  // Write the mtx data to a file
+  std::ofstream ofs("test.mtx");
+  ofs << mtx_data;
+  ofs.close();
+
+  // Write the mtx data with values to a file
+  std::ofstream ofs2("test_values.mtx");
+  ofs2 << mtx_data_with_values;
+  ofs2.close();
+
+  // Read non-weighted file using sparsebase
+  auto coo = sparsebase::utils::io::IOBase::ReadMTXToCOO<int, int, int>("test.mtx", true);
+
+  // Check the dimensions
+  EXPECT_EQ(coo->get_dimensions()[0], 5);
+  EXPECT_EQ(coo->get_dimensions()[1], 5);
+  EXPECT_EQ(coo->get_num_nnz(), 5);
+
+  // Check that the arrays are populated
+  EXPECT_NE(coo->get_row(), nullptr);
+  EXPECT_NE(coo->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo->get_row()[i], row[i]);
+    EXPECT_EQ(coo->get_col()[i], col[i]);
+  }
+
+  // Read the weighted file using sparsebase
+  auto coo2 = sparsebase::utils::io::IOBase::ReadMTXToCOO<int, int, float>("test_values.mtx", true);
+
+  // Check the dimensions
+  EXPECT_EQ(coo2->get_dimensions()[0], 5);
+  EXPECT_EQ(coo2->get_dimensions()[1], 5);
+  EXPECT_EQ(coo2->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(coo2->get_vals(), nullptr);
+  EXPECT_NE(coo2->get_row(), nullptr);
+  EXPECT_NE(coo2->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo2->get_row()[i], row[i]);
+    EXPECT_EQ(coo2->get_col()[i], col[i]);
+    EXPECT_EQ(coo2->get_vals()[i], vals[i]);
+  }
+}
+TEST(IOBase, ReadEdgeListToCSR) {
+
+  // Write the edge list data to a file
+  std::ofstream ofs("test.edges");
+  ofs << edge_list_data;
+  ofs.close();
+
+  // Write the edge list data with values to a file
+  std::ofstream ofs2("test_values.edges");
+  ofs2 << edge_list_data_with_values;
+  ofs2.close();
+
+  // Read it using sparsebase (undirected)
+  auto  csr = utils::io::IOBase::ReadEdgeListToCSR<int, int, int>("test.edges");
+
+  // Check the dimensions (double the edges due to undirected read)
+  EXPECT_EQ(csr->get_num_nnz(), 10);
+  EXPECT_NE(csr->get_row_ptr(), nullptr);
+  EXPECT_NE(csr->get_col(), nullptr);
+
+  // To test integrity we create an edge_set from the known values
+  // And check if every edge read is a member of that
+  // This is done due to the fact that this is an undirected read
+  std::set<std::pair<int, int>> edge_set;
+  for (int i = 0; i < 5; i++) {
+    edge_set.emplace(row[i], col[i]);
+    edge_set.emplace(col[i], row[i]);
+  }
+  for (int i = 0; i < 5; i++) {
+    for (int j =csr->get_row_ptr()[i]; j < csr->get_row_ptr()[i+1]; j++) {
+      std::pair<int, int> p(i, csr->get_col()[j]);
+      EXPECT_NE(edge_set.find(p), edge_set.end());
+    }
+  }
+
+  // Read it using sparsebase (directed)
+  auto csr2 = utils::io::IOBase::ReadEdgeListToCSR<int, int, float>("test.edges", false, false, false);
+
+  // Check the dimensions
+  EXPECT_EQ(csr2->get_num_nnz(), 5);
+  EXPECT_NE(csr2->get_row_ptr(), nullptr);
+  EXPECT_NE(csr2->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr2->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr2->get_col()[i], col[i]);
+  }
+
+  // Read it using sparsebase (weighted, directed)
+  auto csr3 = utils::io::IOBase::ReadEdgeListToCSR<int, int, float>("test_values.edges", true, false, false);
+
+  // Check the dimensions
+  EXPECT_EQ(csr3->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(csr3->get_vals(), nullptr);
+  EXPECT_NE(csr3->get_row_ptr(), nullptr);
+  EXPECT_NE(csr3->get_col(), nullptr);
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr3->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr3->get_col()[i], col[i]);
+    EXPECT_EQ(csr3->get_vals()[i], vals[i]);
+  }
+}
+TEST(IOBase, ReadEdgeListToCOO) {
+
+  // Write the edge list data to a file
+  std::ofstream ofs("test.edges");
+  ofs << edge_list_data;
+  ofs.close();
+
+  // Write the edge list data with values to a file
+  std::ofstream ofs2("test_values.edges");
+  ofs2 << edge_list_data_with_values;
+  ofs2.close();
+
+  // Read it using sparsebase (undirected)
+  auto coo = utils::io::IOBase::ReadEdgeListToCOO<int, int, int>("test.edges");
+
+  // Check the dimensions (double the edges due to undirected read)
+  EXPECT_EQ(coo->get_num_nnz(), 10);
+  EXPECT_NE(coo->get_row(), nullptr);
+  EXPECT_NE(coo->get_col(), nullptr);
+
+  // To test integrity we create an edge_set from the known values
+  // And check if every edge read is a member of that
+  // This is done due to the fact that this is an undirected read
+  std::set<std::pair<int, int>> edge_set;
+  for (int i = 0; i < 5; i++) {
+    edge_set.emplace(row[i], col[i]);
+    edge_set.emplace(col[i], row[i]);
+  }
+  for (int i = 0; i < 10; i++) {
+    std::pair<int, int> p(coo->get_row()[i], coo->get_col()[i]);
+    EXPECT_NE(edge_set.find(p), edge_set.end());
+  }
+
+  // Read it using sparsebase (directed)
+  auto coo2 = utils::io::IOBase::ReadEdgeListToCOO<int, int, int>("test.edges", false, false, false);
+
+  // Check the dimensions
+  EXPECT_EQ(coo2->get_num_nnz(), 5);
+  EXPECT_NE(coo2->get_row(), nullptr);
+  EXPECT_NE(coo2->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo2->get_row()[i], row[i]);
+    EXPECT_EQ(coo2->get_col()[i], col[i]);
+  }
+
+  // Read it using sparsebase (weighted, directed)
+  auto coo3 = utils::io::IOBase::ReadEdgeListToCOO<int, int, float>("test_values.edges", true, false, false);
+
+  // Check the dimensions
+  EXPECT_EQ(coo3->get_num_nnz(), 5);
+
+  // vals array should not be empty or null (same for the other arrays)
+  EXPECT_NE(coo3->get_vals(), nullptr);
+  EXPECT_NE(coo3->get_row(), nullptr);
+  EXPECT_NE(coo3->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo3->get_row()[i], row[i]);
+    EXPECT_EQ(coo3->get_col()[i], col[i]);
+    EXPECT_EQ(coo3->get_vals()[i], vals[i]);
+  }
+}
+TEST(IOBase, ReadPigoEdgeListToCOO) {
+  // Write the edge list data to a file
+  std::ofstream ofs("test_pigo.edges");
+  ofs << edge_list_data;
+  ofs.close();
+
+  // Write the edge list data with values to a file
+  std::ofstream ofs2("test_values_pigo.edges");
+  ofs2 << edge_list_data_with_values;
+  ofs2.close();
+
+  auto coo = utils::io::IOBase::ReadPigoEdgeListToCOO<int, int, int>(
+      "test_pigo.edges", false);
+
+  // Check the dimensions (double the edges due to undirected read)
+  EXPECT_EQ(coo->get_num_nnz(), 5);
+  EXPECT_NE(coo->get_row(), nullptr);
+  EXPECT_NE(coo->get_col(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo->get_row()[i], row[i]);
+    EXPECT_EQ(coo->get_col()[i], col[i]);
+  }
+
+  auto coo2 = utils::io::IOBase::ReadPigoEdgeListToCOO<int, int, float>(
+      "test_values_pigo.edges", true);
+
+  // Check the dimensions (double the edges due to undirected read)
+  EXPECT_EQ(coo2->get_num_nnz(), 5);
+  EXPECT_NE(coo2->get_row(), nullptr);
+  EXPECT_NE(coo2->get_col(), nullptr);
+  EXPECT_NE(coo2->get_vals(), nullptr);
+
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(coo2->get_row()[i], row[i]);
+    EXPECT_EQ(coo2->get_col()[i], col[i]);
+    EXPECT_EQ(coo2->get_vals()[i], vals[i]);
+  }
+}
+
+TEST(IOBase, ReadPigoEdgeListToCSR) {
+  // Write the edge list data to a file
+  std::ofstream ofs("test_pigo.edges");
+  ofs << edge_list_data;
+  ofs.close();
+
+  // Write the edge list data with values to a file
+  std::ofstream ofs2("test_values_pigo.edges");
+  ofs2 << edge_list_data_with_values;
+  ofs2.close();
+
+  auto csr = utils::io::IOBase::ReadPigoEdgeListToCSR<int, int, int>(
+      "test_pigo.edges", false);
+
+  // Check the dimensions (double the edges due to undirected read)
+  EXPECT_EQ(csr->get_num_nnz(), 5);
+  EXPECT_NE(csr->get_row_ptr(), nullptr);
+  EXPECT_NE(csr->get_col(), nullptr);
+
+  for (int i = 0; i < 6; i++) {
+  EXPECT_EQ(csr->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr->get_col()[i], col[i]);
+  }
+
+  auto csr2 = utils::io::IOBase::ReadPigoEdgeListToCSR<int, int, float>(
+      "test_values_pigo.edges", true);
+
+  // Check the dimensions (double the edges due to undirected read)
+  EXPECT_EQ(csr2->get_num_nnz(), 5);
+  EXPECT_NE(csr2->get_row_ptr(), nullptr);
+  EXPECT_NE(csr2->get_col(), nullptr);
+  EXPECT_NE(csr2->get_vals(), nullptr);
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_EQ(csr2->get_row_ptr()[i], row_ptr[i]);
+  }
+  // Check the integrity and order of data
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr2->get_col()[i], col[i]);
+    EXPECT_EQ(csr2->get_vals()[i], vals[i]);
+  }
+}
+TEST(IOBase, ReadToOrderOne) {
+  std::ofstream ofs("one_col.mtx");
+  ofs << mtx_data_one_col_with_values;
+  ofs.close();
+  // Read one column file
+  auto array = utils::io::IOBase::ReadMTXToArray<int, int, float>("one_col.mtx");
   // Check that the arrays are populated
   EXPECT_NE(array->get_vals(), nullptr);
   for (int i= 0; i< 10; i++) std::cout << array->get_vals()[i] <<" ";

--- a/tests/suites/sparsebase/utils/io/writer_tests.cc
+++ b/tests/suites/sparsebase/utils/io/writer_tests.cc
@@ -2,6 +2,90 @@
 #include "gtest/gtest.h"
 #include <string>
 
+TEST(IOBase, WriteArrayToBinary) {
+
+  // Initialize an array for testing
+  int array[5]{1, 2, 3, 4, 5};
+  sparsebase::format::Array<int> sbArray(5, array,
+                                         sparsebase::format::kNotOwned);
+
+  // Write the array to a binary file using sparsebase
+  utils::io::IOBase::WriteArrayToBinary(&sbArray, "test_order_one.bin");
+
+  // Read the array from the binary file using sparsebase
+  sparsebase::utils::io::BinaryReaderOrderOne<int> readerOrderOne(
+      "test_order_one.bin");
+  auto array2 = readerOrderOne.ReadArray();
+
+  // Compare the arrays
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(array[i], array2->get_vals()[i]);
+  }
+}
+
+TEST(IOBase, WriteCOOToBinary) {
+
+  // Initialize a COO for testing
+  int row[4]{1, 2, 3, 4};
+  int col[4]{5, 6, 7, 8};
+  float vals[4]{0.1, 0.2, 0.3, 0.4};
+  sparsebase::format::COO<int, int, float> coo(4, 4, 4, row, col, vals,
+                                               sparsebase::format::kNotOwned);
+
+  // Write the COO to a binary file with sparsebase
+  utils::io::IOBase::WriteCOOToBinary(
+      &coo, "writer_test_order_two_coo.bin");
+
+  // Read the COO from the binary file with sparsebase
+  sparsebase::utils::io::BinaryReaderOrderTwo<int, int, float> readerOrderTwo(
+      "writer_test_order_two_coo.bin");
+  auto coo2 = readerOrderTwo.ReadCOO();
+
+  // Compare the dimensions
+  EXPECT_EQ(coo.get_dimensions(), coo2->get_dimensions());
+  EXPECT_EQ(coo.get_num_nnz(), coo2->get_num_nnz());
+
+  // Compare the underlying arrays
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(coo.get_row()[i], coo2->get_row()[i]);
+    EXPECT_EQ(coo.get_col()[i], coo2->get_col()[i]);
+    EXPECT_EQ(coo.get_vals()[i], coo2->get_vals()[i]);
+  }
+}
+
+TEST(IOBase, WriteBinaryToCSR) {
+
+  // Initialize a CSR for testing
+  int row_ptr[5]{0, 2, 3, 3, 4};
+  int col[4]{0, 2, 1, 3};
+  float vals[4]{0.1, 0.2, 0.3, 0.4};
+
+  sparsebase::format::CSR<int, int, float> csr(4, 4, row_ptr, col, vals,
+                                               sparsebase::format::kNotOwned);
+
+  // Write the COO to a binary file with sparsebase
+  utils::io::IOBase::WriteCSRToBinary(&csr,
+      "writer_test_order_two_csr.bin");
+
+  // Read the COO from the binary file with sparsebase
+  sparsebase::utils::io::BinaryReaderOrderTwo<int, int, float> readerOrderTwo(
+      "writer_test_order_two_csr.bin");
+  auto csr2 = readerOrderTwo.ReadCSR();
+
+  // Compare the dimensions
+  EXPECT_EQ(csr.get_dimensions(), csr2->get_dimensions());
+  EXPECT_EQ(csr.get_num_nnz(), csr2->get_num_nnz());
+
+  // Compare the underlying arrays
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(csr.get_col()[i], csr2->get_col()[i]);
+    EXPECT_EQ(csr.get_vals()[i], csr2->get_vals()[i]);
+  }
+
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(csr.get_row_ptr()[i], csr2->get_row_ptr()[i]);
+  }
+}
 TEST(BinaryOrderOneWriter, Basics) {
 
   // Initialize an array for testing


### PR DESCRIPTION
Added IOBase as described in #150. Specifically, the changes made are:

* Added reading calls for the readers of edge lists, edge lists with Pigo, matrix markets, matrix markets with Pigo, and SparseBase's binary format for both orders one and two.
* Added writer calls for SparseBase's binary format orders one and two.
* Reading is for COO, CSR, and Array formats whenever it is implemented.
* Added tests for all added calls.