### PR TITLE
Docs/dependency docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ If you are new to the project, we suggest starting here: :doc:`pages/getting_sta
    :maxdepth: 2
 
 
-   pages/getting_started
+   pages/getting_started/index
    pages/tutorials/index
    pages/explanations/index
    pages/how_to_guides/index

--- a/docs/pages/contributing/dependencies.md
+++ b/docs/pages/contributing/dependencies.md
@@ -1,8 +1,8 @@
 # Adding New Dependencies
 
 SparseBase contains two different types of dependencies:
-- Required dependencies
-- Optional dependencies
+- Required dependencies.
+- Optional dependencies.
 
 ## Required Dependencies
 
@@ -15,9 +15,11 @@ Currently, for choosing required dependencies we suggest the following options i
 3. Look for UNIX commandline tools
 4. Open a [Github](https://github.com/sparcityeu/sparsebase) issue for discussion
 
-> SparseBase is designed as an HPC library, so you shouldn't be forced to use a header-only solution
-> if it lacks the performance necessary. If this is the case please open an issue on 
-> [Github](https://github.com/sparcityeu/sparsebase) so that we can discuss.
+```{note}
+SparseBase is designed as an HPC library, so you shouldn't be forced to use a header-only solution
+if it lacks the performance necessary. If this is the case please open an issue on 
+[Github](https://github.com/sparcityeu/sparsebase) so that we can discuss.
+```
 
 ### Header Only Dependencies
 
@@ -42,8 +44,10 @@ another can not be directly bundled with SparseBase. Some examples:
 - [METIS](https://github.com/KarypisLab/METIS) (Has some compilation options that are best chosen by the user)
 - [PATOH](https://faculty.cc.gatech.edu/~umit/software.html) (Not open-source)
 
-> If the dependency is header-only we suggest treating it as a required dependency 
-> even if it doesn't have substantial effect on the library
+```{note}
+If the dependency is header-only we suggest treating it as a required dependency 
+even if it doesn't have substantial effect on the library.
+```
 
 Optional dependencies must be build separately by users.
 
@@ -51,32 +55,32 @@ Here are the steps to add an optional dependency:
 
 1. In the `src/CMakeLists.txt` file add a new option in the form `USE_<dependency>`. 
 This will be set by the user to turn the dependency ON or OFF. It should always default to OFF.
-```cmake
-option(USE_METIS "Enable METIS integration" OFF)
-```
+    ```cmake
+    option(USE_METIS "Enable METIS integration" OFF)
+    ```
 
 2. In the same file call the `add_opt_library` macro with the name of the library if it is ON.
 This name should match the library's built file (ie, `lib<name>.so` or `lib<name>.a` etc.)
-```cmake
-if(USE_METIS)
-    add_opt_library("metis")
-endif()
-```
+    ```cmake
+    if(USE_METIS)
+        add_opt_library("metis")
+    endif()
+    ```
 
 3. In the `src/config.h.in` file add `#cmakedefine USE_<dependency>`
-```cpp
-#cmakedefine USE_METIS
-```
+    ```cpp
+    #cmakedefine USE_METIS
+    ```
 
 4. Now the dependency should be accessible. The included files will be in `sparsebase/external/<dependency>`. 
 You should surround every usage with `#ifdef USE_<dependency> ... #endif`.
-```cpp
-#ifdef USE_METIS
+    ```cpp
+    #ifdef USE_METIS
 
-#include "sparsebase/external/metis/metis.h"
+    #include "sparsebase/external/metis/metis.h"
 
-template <typename IDType, typename NNZType, typename ValueType>
-MetisPartition<IDType, NNZType, ValueType>::MetisPartition(){...}
+    template <typename IDType, typename NNZType, typename ValueType>
+    MetisPartition<IDType, NNZType, ValueType>::MetisPartition(){...}
 
-#endif
-```
+    #endif
+    ```

--- a/docs/pages/contributing/dependencies.md
+++ b/docs/pages/contributing/dependencies.md
@@ -13,10 +13,11 @@ Currently, for choosing required dependencies we suggest the following options i
 1. Look for header-only libraries
 2. Check if it can be achieved by calling a Python script (we already depend on Python in our build system)
 3. Look for UNIX commandline tools
-4. Open an Github issue for discussion
+4. Open a [Github](https://github.com/sparcityeu/sparsebase) issue for discussion
 
 > SparseBase is designed as an HPC library, so you shouldn't be forced to use a header-only solution
-> if it lacks the performance necessary. If this is the case please open an issue on Github so that we can discuss.
+> if it lacks the performance necessary. If this is the case please open an issue on 
+> [Github](https://github.com/sparcityeu/sparsebase) so that we can discuss.
 
 ### Header Only Dependencies
 
@@ -26,7 +27,7 @@ the license for the dependency.
 
 When choosing a header-only dependency please make sure it uses a permissive license (like MIT,Apache,BSD).
 Copy-left licences (like GPL) can cause legal issues since the SparseBase itself uses a permissive license.
-If you are not sure, please open an issue on Github.
+If you are not sure, please open an issue on [Github](https://github.com/sparcityeu/sparsebase).
 
 
 ### Calling Python and UNIX Tools

--- a/docs/pages/contributing/dependencies.md
+++ b/docs/pages/contributing/dependencies.md
@@ -1,0 +1,81 @@
+# Adding New Dependencies
+
+SparseBase contains two different types of dependencies:
+- Required dependencies
+- Optional dependencies
+
+## Required Dependencies
+
+A dependency is required if the library loses a substantial amount of functionality without it.
+To keep the library simple and cross-platform, we currently avoid all required non-header-only dependencies.
+
+Currently, for choosing required dependencies we suggest the following options in order of preference:
+1. Look for header-only libraries
+2. Check if it can be achieved by calling a Python script (we already depend on Python in our build system)
+3. Look for UNIX commandline tools
+4. Open an Github issue for discussion
+
+> SparseBase is designed as an HPC library, so you shouldn't be forced to use a header-only solution
+> if it lacks the performance necessary. If this is the case please open an issue on Github so that we can discuss.
+
+### Header Only Dependencies
+
+All header-only dependencies must be located in their own directory located at `src/sparsebase/external`
+This directory should contain the header files to be included as well as a LICENSE file containing 
+the license for the dependency.
+
+When choosing a header-only dependency please make sure it uses a permissive license (like MIT,Apache,BSD).
+Copy-left licences (like GPL) can cause legal issues since the SparseBase itself uses a permissive license.
+If you are not sure, please open an issue on Github.
+
+
+### Calling Python and UNIX Tools
+
+This can be achieved easily by using [std::system](https://en.cppreference.com/w/cpp/utility/program/system)
+
+
+## Optional Dependencies
+
+Optional dependencies in the context of SparseBase are libraries that for one reason or 
+another can not be directly bundled with SparseBase. Some examples:
+- [METIS](https://github.com/KarypisLab/METIS) (Has some compilation options that are best chosen by the user)
+- [PATOH](https://faculty.cc.gatech.edu/~umit/software.html) (Not open-source)
+
+> If the dependency is header-only we suggest treating it as a required dependency 
+> even if it doesn't have substantial effect on the library
+
+Optional dependencies must be build separately by users.
+
+Here are the steps to add an optional dependency:
+
+1. In the `src/CMakeLists.txt` file add a new option in the form `USE_<dependency>`. 
+This will be set by the user to turn the dependency ON or OFF. It should always default to OFF.
+```cmake
+option(USE_METIS "Enable METIS integration" OFF)
+```
+
+2. In the same file call the `add_opt_library` macro with the name of the library if it is ON.
+This name should match the library's built file (ie, `lib<name>.so` or `lib<name>.a` etc.)
+```cmake
+if(USE_METIS)
+    add_opt_library("metis")
+endif()
+```
+
+3. In the `src/config.h.in` file add `#cmakedefine USE_<dependency>`
+```cpp
+#cmakedefine USE_METIS
+```
+
+4. Now the dependency should be accessible. The included files will be in `sparsebase/external/<dependency>`. 
+You should surround every usage with `#ifdef USE_<dependency> ... #endif`.
+```cpp
+#ifdef USE_METIS
+
+#include "sparsebase/external/metis/metis.h"
+
+template <typename IDType, typename NNZType, typename ValueType>
+MetisPartition<IDType, NNZType, ValueType>::MetisPartition(){...}
+
+#endif
+```

--- a/docs/pages/contributing/instantiations.md
+++ b/docs/pages/contributing/instantiations.md
@@ -1,0 +1,66 @@
+# Instantiating Classes in SparseBase
+
+While SparseBase supports a header-only mode, our main focus is in the compiled version of the library. 
+This is mainly due to the large impact of header-only mode on the build times of user's projects.
+
+As a result of this, we try to keep the header files as light as possible by avoiding putting implementations there.
+There are a few exceptions to this (like the `As<>()` function of `Format`) 
+but this is only done in very rare situations.
+
+Hence, any templated class or function you create in SparseBase will require instantiation as it needs to be compiled
+with the library with the types known at compile time. This is achieved with the script 
+`src/generate_explicit_instantiations.py`.
+
+> Note that this script is not intended to be called manually besides debugging. It will be called automatically
+> by CMake during the configuration step
+
+To add a new instantiation you need to call the following function. Each parameter is explained in its own section.
+
+```python
+def gen_inst(template, filename, ifdef=None, folder=output_folder):
+```
+
+## Template
+
+**Example:** `CSR<$id_type, $nnz_type, $value_type>`
+
+The following operations will be performed on the template you provide:
+
+1. Template will be placed in `template class <your_template>;\n`
+2. The identifiers starting with `$` will be replaced with their counterparts in the CMake variables. Currently, we have
+`$id_type`, `$nnz_type`, `$value_type`, `$float_type`. Every possible combination will be covered.
+
+
+## Filename
+
+The filename to be used for the output. As per [Google's Style Guide](https://google.github.io/styleguide/cppguide.html),
+the filenames we use end with the `.inc` extension. 
+
+> Caution!!! If the file is being used for the first time you should also call the `reset_file()` function with it.
+> Otherwise you may encounter duplicate instantiation errors
+
+## Ifdef
+
+This is an optional parameter. If used, the instantiations will be surrounded with an `#ifdef ... #endif` using the 
+string provided in this parameter as the definition name.
+
+**Example:**
+
+```cpp
+// Generated when the function is called with ifdef="USE_METIS" 
+#ifdef USE_METIS
+template class MetisPartition<int,int,double>;
+template class MetisPartition<int,int,float>;
+#endif
+```
+
+## Folder
+
+By default, the script will put everything in the `output_folder` argument passed by CMake. 
+This optional parameter can be used to override that.
+Generally you will want to use this to open a new folder under `output_folder`.
+
+> Caution!!! Files under different folders are different from each other. And as a result the `reset_file()`
+> function must be called on each file separately. Note that `reset_file()` also takes an optional folder 
+> parameter for this purpose.
+

--- a/docs/pages/contributing/instantiations.md
+++ b/docs/pages/contributing/instantiations.md
@@ -11,8 +11,10 @@ Hence, any templated class or function you create in SparseBase will require ins
 with the library with the types known at compile time. This is achieved with the script 
 `src/generate_explicit_instantiations.py`.
 
-> Note that this script is not intended to be called manually besides debugging. It will be called automatically
-> by CMake during the configuration step
+```{note}
+This script is not intended to be called manually besides debugging. It will be called automatically
+by CMake during the configuration step.
+```
 
 To add a new instantiation you need to call the following function. Each parameter is explained in its own section.
 
@@ -36,8 +38,10 @@ The following operations will be performed on the template you provide:
 The filename to be used for the output. As per [Google's Style Guide](https://google.github.io/styleguide/cppguide.html),
 the filenames we use end with the `.inc` extension. 
 
-> Caution!!! If the file is being used for the first time you should also call the `reset_file()` function with it.
-> Otherwise you may encounter duplicate instantiation errors
+```{warning}
+If the file is being used for the first time you should also call the `reset_file()` function with it.
+Otherwise you may encounter duplicate instantiation errors
+```
 
 ## Ifdef
 
@@ -60,7 +64,8 @@ By default, the script will put everything in the `output_folder` argument passe
 This optional parameter can be used to override that.
 Generally you will want to use this to open a new folder under `output_folder`.
 
-> Caution!!! Files under different folders are different from each other. And as a result the `reset_file()`
-> function must be called on each file separately. Note that `reset_file()` also takes an optional folder 
-> parameter for this purpose.
-
+```{warning}
+Files under different folders are different from each other. And as a result the `reset_file()`
+function must be called on each file separately. Note that `reset_file()` also takes an optional folder 
+parameter for this purpose.
+```

--- a/docs/pages/getting_started/index.rst
+++ b/docs/pages/getting_started/index.rst
@@ -1,0 +1,10 @@
+Getting Started
+=============
+
+This section includes everything you need to now to install and link sparsebase.
+
+.. toctree::
+   :glob:
+   :maxdepth: 2
+
+   ./*

--- a/docs/pages/getting_started/installation_building.md
+++ b/docs/pages/getting_started/installation_building.md
@@ -1,0 +1,86 @@
+# Installation & Building
+
+## Requirements
+
+Compilers listed below are the ones we used during development and testing.
+Other compilers may work but are not officially supported at the moment.
+Lowest versions are included based on the feature sets of the tools/compilers
+and not all of them are tested.
+We suggest using the most recent versions when possible.
+
+- Supported Compilers:
+    - clang++ (version 6 or above)
+    - g++ (version 7 or above)
+    - MSYS2 g++ ([mingw-w64-x86_64-gcc](https://packages.msys2.org/package/mingw-w64-x86_64-gcc?repo=mingw64))
+
+
+- Build tools:
+    - cmake (version 3.0 or above)
+    - GNU make (version 4.1 or above) or ninja (version 1.11 or above)
+    
+
+## Compiling
+
+> A version of the header-only release can be obtained in the releases section on Github 
+> (no compilation needed)
+> along with a documentation pdf and license information.
+> We still suggest compiling and using a non-header-only build if possible
+> for faster compile times on your projects.
+
+```bash
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCUDA={$CUDA} ..
+make
+```
+Where `${CUDA}` is `ON` if CUDA support is needed and `OFF` otherwise.
+
+This will generate the library as a static library. In addition, the example codes are compiled and their binaries are located in `build/examples`.
+
+Due to optimizations and templates, this process might take several minutes.
+
+## Specifying explicit instantiation types
+Most classes in the library are templated over four template parameter types:
+
+1. `IDType`: data type that will contain IDs of element in a format object.
+2. `NNZType`: data type that will contain numbers of non-zeros in a format object. 
+3. `ValueType`: data type that will contain values stored inside format objects.
+4. `FloatType`: data type that will contain floating point values (e.g., degree distributions).
+
+When generating the build system, you can specify a list of data types for each one of these template parameters. Explicit instantiations of all the classes in the library will be created to satisfy the power set of all the types you passed. You can specify the data types using CMake cache variables that you pass as semi-colon-seperated, quotation-enclosed lists. For example, the following command:
+```bash
+cmake -DID_TYPES="unsigned int; unsigned long long" -DNNZ_TYPES="unsigned long long; short" -DVALUE_TYPES="float" -DFLOAT_TYPES="double; float" ..
+```
+specifies the data types to be used with each of the four template parameter types stated above. 
+
+Alternatively, you can edit the `CMakeCache.txt` file located in the build directory. Note that this file is generated after creating the build system (after executing `cmake`).
+
+## Header-only
+
+
+Additionally, the library has a header-only setting, in which none of the classes of the library will be explicitly instantiated at library-build time. Building the library to be header-only can be done as shown:
+```
+mkdir build && cd build
+cmake -D_HEADER_ONLY=ON -DCMAKE_BUILD_TYPE=Release -DCUDA=${CUDA} ..
+make
+```
+Where `${CUDA}` is `ON` if CUDA support is needed and `OFF` otherwise.
+
+> Note: if the library is installed with `${CUDA}=ON`, the user code must be compiled using `nvcc`.
+
+This will prepare the library for installation and compile the example codes located in `build/examples`.
+
+
+## Installation
+
+To install the library, compile the library as shown in the previous section. Afterwards, you can install the library files either to the systems global location or to a custom location. To install the library to the default system location:
+```bash
+cd build
+cmake --install .
+```
+
+To install the library to a custom directory, do the following:
+```bash
+cd build
+cmake --install . --prefix "/custom/location"
+```
+**Note:** We suggest using **absolute paths** for prefixes as relative paths have been known to cause problems from time to time.

--- a/docs/pages/getting_started/optional_dependencies.md
+++ b/docs/pages/getting_started/optional_dependencies.md
@@ -37,7 +37,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_METIS=ON
 Example for METIS using cmake variables:
 ```bash
 mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_METIS=ON 
+cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_METIS=ON \
   -DMETIS_LIB_DIR=/home/user/lib/metis/lib -DMETIS_INC_DIR=/home/user/lib/metis/include
 ```
 

--- a/docs/pages/getting_started/optional_dependencies.md
+++ b/docs/pages/getting_started/optional_dependencies.md
@@ -9,19 +9,21 @@ or another can not be directly bundled sparsebase.
 
 ## Compiling With An Optional Dependency
 
-To enable an optional dependency the user must either pass `-DUSE_<dependency>=ON` parameter to cmake. 
-Or set it afterwards in the `CMakeCache.txt` file and rerun cmake.
+To enable an optional dependency the user must either pass `-DUSE_<dependency>=ON` parameter to cmake, 
+or set it afterwards in the `CMakeCache.txt` file and rerun cmake.
 
 Once this is done cmake will automatically search for the library. It will look at the following locations by default:
-- User defined `CMAKE_PREFIX_PATH` variable
-- System defined `CMAKE_SYSTEM_PREFIX_PATH` variable
+- User defined `CMAKE_PREFIX_PATH` variable.
+- System defined `CMAKE_SYSTEM_PREFIX_PATH` variable.
 
 If the library is located in a usual place (like `/usr/local` in Linux) then this should be sufficient.
 However, if cmake fails to find the library the following options could also be set:
-- `<dependency>_LIB_DIR` : Path to the directory containing the `.so`, `.a`, `.dll` file
-- `<dependency>_INC_DIR` : Path to the directory containing the header files
+- `<dependency>_LIB_DIR` : Path to the directory containing the `.so`, `.a`, `.dll` file.
+- `<dependency>_INC_DIR` : Path to the directory containing the header files.
 
-> When passing paths to cmake, we suggest using absolute paths and avoiding symbols like `~` and `*`
+```{note}
+When passing paths to cmake, we suggest using absolute paths and avoiding symbols like `~` and `*`
+```
 
 These are defined both as cmake variables and environment variables, 
 meaning one can set these in `CMakeCache.txt` or using `export` UNIX command.
@@ -43,9 +45,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_METIS=ON \
 
 
 CMake will search in the following order:
-- CMake variables
-- Environment variables
-- User defined prefix
-- System defined prefix
+- CMake variables.
+- Environment variables.
+- User defined prefix.
+- System defined prefix.
 
 As a result of this, the environment and cmake variables can be used to shadow a default installation.

--- a/docs/pages/getting_started/optional_dependencies.md
+++ b/docs/pages/getting_started/optional_dependencies.md
@@ -1,0 +1,51 @@
+# Optional Dependencies
+
+Optional dependencies in the context of sparsebase are libraries that for one reason 
+or another can not be directly bundled sparsebase. 
+
+## Optional Dependency List
+
+- [METIS](https://github.com/KarypisLab/METIS)
+
+## Compiling With An Optional Dependency
+
+To enable an optional dependency the user must either pass `-DUSE_<dependency>=ON` parameter to cmake. 
+Or set it afterwards in the `CMakeCache.txt` file and rerun cmake.
+
+Once this is done cmake will automatically search for the library. It will look at the following locations by default:
+- User defined `CMAKE_PREFIX_PATH` variable
+- System defined `CMAKE_SYSTEM_PREFIX_PATH` variable
+
+If the library is located in a usual place (like `/usr/local` in Linux) then this should be sufficient.
+However, if cmake fails to find the library the following options could also be set:
+- `<dependency>_LIB_DIR` : Path to the directory containing the `.so`, `.a`, `.dll` file
+- `<dependency>_INC_DIR` : Path to the directory containing the header files
+
+> When passing paths to cmake, we suggest using absolute paths and avoiding symbols like `~` and `*`
+
+These are defined both as cmake variables and environment variables, 
+meaning one can set these in `CMakeCache.txt` or using `export` UNIX command.
+
+Example for METIS using environment variables:
+```bash
+mkdir build && cd build
+export METIS_LIB_DIR=/home/user/lib/metis/lib
+export METIS_INC_DIR=/home/user/lib/metis/include
+cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_METIS=ON
+```
+
+Example for METIS using cmake variables:
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_METIS=ON 
+  -DMETIS_LIB_DIR=/home/user/lib/metis/lib -DMETIS_INC_DIR=/home/user/lib/metis/include
+```
+
+
+CMake will search in the following order:
+- CMake variables
+- Environment variables
+- User defined prefix
+- System defined prefix
+
+As a result of this, the environment and cmake variables can be used to shadow a default installation.

--- a/docs/pages/getting_started/usage.md
+++ b/docs/pages/getting_started/usage.md
@@ -1,97 +1,8 @@
-# Getting Started
-
-## Installation & Building
-
-### Requirements
-
-Compilers listed below are the ones we used during development and testing.
-Other compilers may work but are not officially supported at the moment.
-Lowest versions are included based on the feature sets of the tools/compilers
-and not all of them are tested.
-We suggest using the most recent versions when possible.
-
-- Supported Compilers:
-    - clang++ (version 6 or above)
-    - g++ (version 7 or above)
-    - MSYS2 g++ ([mingw-w64-x86_64-gcc](https://packages.msys2.org/package/mingw-w64-x86_64-gcc?repo=mingw64))
-
-
-- Build tools:
-    - cmake (version 3.0 or above)
-    - GNU make (version 4.1 or above) or ninja (version 1.11 or above)
-    
-
-### Compiling
-
-> A version of the header-only release can be obtained in the releases section on Github 
-> (no compilation needed)
-> along with a documentation pdf and license information.
-> We still suggest compiling and using a non-header-only build if possible
-> for faster compile times on your projects.
-
-```bash
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCUDA={$CUDA} ..
-make
-```
-Where `${CUDA}` is `ON` if CUDA support is needed and `OFF` otherwise.
-
-This will generate the library as a static library. In addition, the example codes are compiled and their binaries are located in `build/examples`.
-
-Due to optimizations and templates, this process might take several minutes.
-
-### Specifying explicit instantiation types
-Most classes in the library are templated over four template parameter types:
-
-1. `IDType`: data type that will contain IDs of element in a format object.
-2. `NNZType`: data type that will contain numbers of non-zeros in a format object. 
-3. `ValueType`: data type that will contain values stored inside format objects.
-4. `FloatType`: data type that will contain floating point values (e.g., degree distributions).
-
-When generating the build system, you can specify a list of data types for each one of these template parameters. Explicit instantiations of all the classes in the library will be created to satisfy the power set of all the types you passed. You can specify the data types using CMake cache variables that you pass as semi-colon-seperated, quotation-enclosed lists. For example, the following command:
-```bash
-cmake -DID_TYPES="unsigned int; unsigned long long" -DNNZ_TYPES="unsigned long long; short" -DVALUE_TYPES="float" -DFLOAT_TYPES="double; float" ..
-```
-specifies the data types to be used with each of the four template parameter types stated above. 
-
-Alternatively, you can edit the `CMakeCache.txt` file located in the build directory. Note that this file is generated after creating the build system (after executing `cmake`).
-
-### Header-only
-
-
-Additionally, the library has a header-only setting, in which none of the classes of the library will be explicitly instantiated at library-build time. Building the library to be header-only can be done as shown:
-```
-mkdir build && cd build
-cmake -D_HEADER_ONLY=ON -DCMAKE_BUILD_TYPE=Release -DCUDA=${CUDA} ..
-make
-```
-Where `${CUDA}` is `ON` if CUDA support is needed and `OFF` otherwise.
-
-> Note: if the library is installed with `${CUDA}=ON`, the user code must be compiled using `nvcc`.
-
-This will prepare the library for installation and compile the example codes located in `build/examples`.
-
-
-### Installation
-
-To install the library, compile the library as shown in the previous section. Afterwards, you can install the library files either to the systems global location or to a custom location. To install the library to the default system location:
-```bash
-cd build
-cmake --install .
-```
-
-To install the library to a custom directory, do the following:
-```bash
-cd build
-cmake --install . --prefix "/custom/location"
-```
-**Note:** We suggest using **absolute paths** for prefixes as relative paths have been known to cause problems from time to time.
-
-## Usage
+# Usage
 SparseBase can be easily added to your project either through CMake's `find_package()` command, or by directly linking it at compilation time.
 
 
-### Adding SparseBase through CMake
+## Adding SparseBase through CMake
 
 > In the commands below replace 0.1.5 with the version of SparseBase you installed.
 
@@ -109,7 +20,7 @@ After the library is added to your project, you can simply link your targets to 
 target_link_libraries(your_target sparsebase::sparsebase)
 ```
 
-### Linking to SparseBase at compile time 
+## Linking to SparseBase at compile time 
 If the library is not built in header-only mode, you must link it to your targets by passing the appropriate flag for your compiler. For example, for `g++`, add the `-lsparsebase` flag:
 ```bash
 g++ source.cpp -lsparsebase
@@ -128,7 +39,7 @@ And if the library is not installed in the system-default location:
 g++ source.cpp -I/custom/location/include -L/custom/location/lib
 ```
 
-### Tests
+## Tests
 
 Users can run unit tests easily after building the project. To do so, they must configure CMake to compile tests:
 ```bash
@@ -141,7 +52,8 @@ Once its built, while in the build directory, do the following:
 ```bash
 ctest -V
 ```
-### Formatting
+
+## Formatting
 Source files can be automatically formatted using `clang-format`. After installing `clang-format`, generate the build system using CMake and build the target `format`. This example shows its usage with `make`:
 ```bash
 mkdir build
@@ -150,7 +62,7 @@ cmake ..
 make format
 ``` 
 
-### Including SparseBase
+## Including SparseBase
 
 SparseBase can be included using the ``sparsebase.h`` header file.
 
@@ -166,7 +78,7 @@ This can be useful to reduce compile times if the header only build is being use
 #include "sparsebase/preprocess/preprocess.h"
 ```
 
-### Creating a Format Object
+## Creating a Format Object
 
 Currently two sparse data formats are supported:
 - COO (Coordinate List)
@@ -203,7 +115,7 @@ auto coo = new sparsebase::COO<int,int,int>(6, 6, 6, row, col, vals);
 
 
 
-### Input
+## Input
 
 Currently, we support two sparse data file formats:
 - Matrix Market Files (.mtx)
@@ -220,7 +132,7 @@ auto reader2 = new sparsebase::utils::io::EdgeListReader<vertex_type, edge_type,
 auto csr = reader2->ReadCSR();
 ```
 
-### Casting Formats
+## Casting Formats
 
 Many functions in the library return generic format pointers like ``FormatOrderTwo`` or ``FormatOrderOne`` to ensure flexibility. These pointers can easily be converted into concrete versions using the ``Convert<>()`` member function. 
 
@@ -245,7 +157,7 @@ sparsebase::format::CSR<int,int,int>* csr = format->As<sparsebase::format::CSR<i
 ```
 
 
-### Converting Formats
+## Converting Formats
 
 As explained in the previous section, readers will read to different formats.
 
@@ -267,7 +179,7 @@ auto csr = coo->Convert<sparsebase::format::CSR>(&cpu_context, true);
 
 > If the source and destination formats are the same the converter will simply do nothing.
 
-### Ownership
+## Ownership
 
 SparseBase allows users to choose whether they want to take responsibility of managing the memory.
 By default the data stored inside ``Format`` instances are considered owned by the instance and as a
@@ -289,7 +201,7 @@ auto* csr_not_owned = new sparsebase::format::CSR<int,int,int>(4, 4, row_ptr, co
 > will almost always be owned by the instance. The user can release the arrays manually as discussed 
 > above if this is not desired.
 
-### Working with Graphs
+## Working with Graphs
 
 Graphs can be created using any SparseFormat as the connectivity information of the graph.
 
@@ -308,7 +220,7 @@ Alternatively we can create a graph by directly passing the reader.
 
 As of the current version of the library, graphs function as containers of sparse data. However, there are plans to expand this in future releases.
 
-### Ordering
+## Ordering
 
 Various orderings can be generated for a graph using the ``ReorderPreprocessType`` classes. 
 Currently these include ``RCMReoder`` and ``DegreeReorder``. There is also a ``GenericReorder`` class

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx==4.3.2
 breathe==4.31.0
 sphinx-rtd_theme==1.0.0
 myst-parser==0.16.1
+attrs==22.1.0


### PR DESCRIPTION
This PR adds documentation to some of the changes made in #153. Specifically it adds the following pages:

- [Getting Started / Optional Dependencies](https://github.com/sparcityeu/sparsebase/blob/docs/dependency_docs/docs/pages/getting_started/optional_dependencies.md)
- [Contributing / Adding New Dependencies](https://github.com/sparcityeu/sparsebase/blob/docs/dependency_docs/docs/pages/contributing/dependencies.md)
- [Contributing / Instantiating Classes](https://github.com/sparcityeu/sparsebase/blob/docs/dependency_docs/docs/pages/contributing/instantiations.md)
