### PR TITLE
Changes to As<>() function in Format and a new Is<>() function

### DIFF
--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -107,11 +107,11 @@ public:
    * CSR<int,int,int>*)
    */
   template <typename T> typename std::remove_pointer<T>::type *As() {
-    using TD = typename std::remove_pointer<T>::type;
-    if (this->get_format_id() == std::type_index(typeid(TD))) {
-      return static_cast<TD *>(this);
+    using TBase = typename std::remove_pointer<T>::type;
+    if (this->get_format_id() == std::type_index(typeid(TBase))) {
+      return static_cast<TBase *>(this);
     }
-    throw utils::TypeException(get_format_id().name(), typeid(TD).name());
+    throw utils::TypeException(get_format_id().name(), typeid(TBase).name());
   }
 
   //! Templated function that can be used to check the concrete type of this object
@@ -120,8 +120,8 @@ public:
    * \return true if the type of this object is T
    */
   template <typename T> bool Is() {
-    using TD = typename std::remove_pointer<T>::type;
-    return this->get_format_id() == std::type_index(typeid(TD));
+    using TBase = typename std::remove_pointer<T>::type;
+    return this->get_format_id() == std::type_index(typeid(TBase));
   }
 
 };

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -106,12 +106,24 @@ public:
    * \return A concrete format pointer to this object (for example:
    * CSR<int,int,int>*)
    */
-  template <typename T> T *As() {
-    if (this->get_format_id() == std::type_index(typeid(T))) {
-      return static_cast<T *>(this);
+  template <typename T> typename std::remove_pointer<T>::type *As() {
+    using TD = typename std::remove_pointer<T>::type;
+    if (this->get_format_id() == std::type_index(typeid(TD))) {
+      return static_cast<TD *>(this);
     }
-    throw utils::TypeException(get_format_id().name(), typeid(T).name());
+    throw utils::TypeException(get_format_id().name(), typeid(TD).name());
   }
+
+  //! Templated function that can be used to check the concrete type of this object
+  /*!
+   * \tparam T a concrete format class (for example: CSR<int,int,int>)
+   * \return true if the type of this object is T
+   */
+  template <typename T> bool Is() {
+    using TD = typename std::remove_pointer<T>::type;
+    return this->get_format_id() == std::type_index(typeid(TD));
+  }
+
 };
 
 //! A class derived from the base Format class, mostly used for development

--- a/tests/suites/sparsebase/format/format_tests.cc
+++ b/tests/suites/sparsebase/format/format_tests.cc
@@ -434,3 +434,30 @@ TEST(CSR, Sort) {
     EXPECT_EQ(csr3.get_col()[i], csr_col[i]);
   }
 }
+
+TEST(Format, Is){
+  int *new_csr_row_ptr = new int[5];
+  int *new_csr_col = new int[4];
+  int *new_csr_vals = new int[4];
+  std::copy(csr_row_ptr, csr_row_ptr + 5, new_csr_row_ptr);
+  std::copy(csr_col, csr_col + 4, new_csr_col);
+  std::copy(csr_vals, csr_vals + 4, new_csr_vals);
+
+  // Construct an owned CSR
+  auto *csr = new sparsebase::format::CSR<int, int, int>(
+      4, 4, new_csr_row_ptr, new_csr_col, new_csr_vals,
+      sparsebase::format::kOwned);
+
+  bool res = csr->Is<format::CSR<int,int,int>>();
+  EXPECT_TRUE(res);
+  res = csr->Is<format::CSR<int,int,int>*>();
+  EXPECT_TRUE(res);
+
+  res = csr->Is<format::COO<int,int,int>>();
+  EXPECT_FALSE(res);
+  res = csr->Is<format::CSR<int,int,float>>();
+  EXPECT_FALSE(res);
+
+  delete csr;
+}
+


### PR DESCRIPTION
This PR should resolved #130 and #131. It makes the following changes/additions:

- A new templated Is<>() function that can check whether the Format pointer is of a particular concrete Format type.
```cpp
if(format->Is<CSR<int,int,int>>()){
  // Do something
}
```

- Some tests are also added for Is<>().

- Both in the new Is<>() function and the old As<>() function, [std::remove_pointer](https://en.cppreference.com/w/cpp/types/remove_pointer) is used to handle calls with pointers correctly as well. This is done to avoid a common misunderstanding (where the user calls the function with the pointer type, not the base type) and also done in some other libraries we reviewed. Unlike what I suggested in #131, [std::decay](https://en.cppreference.com/w/cpp/types/decay) is not used as it actually works differently then I thought. 