### PR TITLE
Demangling Utilities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ if(NOT ${_HEADER_ONLY})
     sparsebase/preprocess/preprocess.cc
     sparsebase/feature/feature.cc
     sparsebase/utils/io/writer.cc
+    sparsebase/utils/utils.cc
   )
   if (${CUDA})
 
@@ -162,8 +163,9 @@ set(IO_FILES
 set(CONVERTER_FILES 
   sparsebase/utils/converter/converter.h
 )
-set(EXCEPTION_FILES 
+set(UTILS_FILES
   sparsebase/utils/exception.h
+  sparsebase/utils/utils.h
 )
 if(${_HEADER_ONLY})
   set(CONTEXT_FILES ${CONTEXT_FILES}
@@ -188,6 +190,10 @@ if(${_HEADER_ONLY})
   set(CONVERTER_FILES ${CONVERTER_FILES}
     sparsebase/utils/converter/converter.cc
   )
+
+  set(UTILS_FILES ${UTILS_FILES}
+     sparsebase/utils/utils.cc
+          )
 endif()
 install(FILES ${SINGLE_HEADER_FILE}
   DESTINATION include)

--- a/src/sparsebase/format/format.cc
+++ b/src/sparsebase/format/format.cc
@@ -12,6 +12,7 @@ using namespace sparsebase::utils;
 
 namespace sparsebase::format {
 
+
 template <typename IDType, typename NNZType, typename ValueType>
 COO<IDType, NNZType, ValueType>::COO(COO<IDType, NNZType, ValueType> &&rhs)
     : col_(std::move(rhs.col_)), row_(std::move(rhs.row_)),

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -10,6 +10,7 @@
 #define SPARSEBASE_SPARSEBASE_FORMAT_FORMAT_H_
 
 #include "sparsebase/config.h"
+#include "sparsebase/utils/utils.h"
 #include "sparsebase/context/context.h"
 #include "sparsebase/utils/exception.h"
 #include <algorithm>
@@ -20,6 +21,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <vector>
+#include <cxxabi.h>
 
 namespace sparsebase {
 
@@ -79,6 +81,10 @@ public:
    * will also have different identifiers.
    */
   virtual std::type_index get_format_id() = 0;
+
+  //! Similar to get_format_id but returns a demangled name instead
+  virtual std::string get_format_name() = 0;
+
   virtual ~Format() = default;
 
   //! Performs a deep copy of the Format object and returns the pointer to the
@@ -143,8 +149,16 @@ public:
   //! instance is a member of
   virtual std::type_index get_format_id() { return typeid(FormatType); }
 
+  virtual std::string get_format_name(){
+    return utils::demangle(get_format_id());
+  };
+
   //! A static variant of the get_format_id() function
   static std::type_index get_format_id_static() { return typeid(FormatType); }
+
+  static std::string get_format_name_static() {
+    return utils::demangle(get_format_id_static());
+  };
 
   virtual std::type_index get_context_type() const {
     return this->context_->get_context_type_member();
@@ -155,6 +169,7 @@ protected:
   std::vector<DimensionType> dimension_;
   DimensionType nnz_;
   std::unique_ptr<sparsebase::context::Context> context_;
+
 };
 
 template <typename ValueType>

--- a/src/sparsebase/preprocess/preprocess.cc
+++ b/src/sparsebase/preprocess/preprocess.cc
@@ -171,7 +171,7 @@ FunctionMatcherMixin<
       std::string message;
       message = "Could not find a function that matches the formats: {";
       for (auto f : packed_sfs) {
-        message += f->get_format_id().name();
+        message += f->get_format_name();
         message += " ";
       }
       message += "} using the contexts {";
@@ -636,7 +636,7 @@ template <typename InputFormatType, typename ReturnFormatType>
 std::tuple<std::vector<format::Format *>, ReturnFormatType *>
 TransformPreprocessType<InputFormatType, ReturnFormatType>::GetTransformationCached(
     format::Format *format, std::vector<context::Context *> contexts, bool convert_input) {
-  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_id().name(), InputFormatType::get_format_id_static().name());
+  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_name(), InputFormatType::get_format_name_static());
   return this->CachedExecute(this->params_.get(), (this->sc_.get()), contexts, convert_input,
                              format);
 }
@@ -646,14 +646,14 @@ std::tuple<std::vector<format::Format *>, ReturnFormatType *>
 TransformPreprocessType<InputFormatType, ReturnFormatType>::GetTransformationCached(
     format::Format  *format, PreprocessParams *params,
     std::vector<context::Context *> contexts, bool convert_input) {
-  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_id().name(), InputFormatType::get_format_id_static().name());
+  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_name(), InputFormatType::get_format_name_static());
   return this->CachedExecute(params, (this->sc_.get()), contexts, convert_input, format);
 }
 
 template <typename InputFormatType, typename ReturnFormatType>
 ReturnFormatType *TransformPreprocessType<InputFormatType, ReturnFormatType>::GetTransformation(
     format::Format *format, std::vector<context::Context *> contexts, bool convert_input) {
-  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_id().name(), InputFormatType::get_format_id_static().name());
+  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_name(), InputFormatType::get_format_name_static());
   return this->Execute(this->params_.get(), (this->sc_.get()), contexts, convert_input, format);
 }
 
@@ -661,7 +661,7 @@ template <typename InputFormatType, typename ReturnFormatType>
 ReturnFormatType *TransformPreprocessType<InputFormatType, ReturnFormatType>::GetTransformation(
     format::Format  *format, PreprocessParams *params,
     std::vector<context::Context *> contexts, bool convert_input) {
-  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_id().name(), InputFormatType::get_format_id_static().name());
+  if (dynamic_cast<InputFormatType*>(format) == nullptr) throw utils::TypeException(format->get_format_name(), InputFormatType::get_format_name_static());
   return this->Execute(params, (this->sc_.get()), contexts, convert_input, format);
 }
 

--- a/src/sparsebase/utils/converter/converter.cc
+++ b/src/sparsebase/utils/converter/converter.cc
@@ -1,5 +1,6 @@
 #include "sparsebase/utils/converter/converter.h"
 #include "sparsebase/format/format.h"
+#include "sparsebase/utils/utils.h"
 #include <iostream>
 #include <set>
 
@@ -414,7 +415,7 @@ Format *Converter::Convert(Format *source, std::type_index to_type,
                               to_type, to_context, is_move_conversion);
     return conv_func(source, to_context);
   } catch (...) {
-    throw ConversionException(source->get_format_id().name(), to_type.name());
+    throw ConversionException(source->get_format_name(), utils::demangle(to_type));
     // mechanism
   }
 }
@@ -437,9 +438,9 @@ ConditionalConversionFunction Converter::GetConversionFunction(
         return std::get<1>(conditional_function_tuple);
       }
     }
-    throw ConversionException(from_type.name(), to_type.name());
+    throw ConversionException(utils::demangle(from_type), utils::demangle(to_type));
   } catch (...) {
-    throw ConversionException(from_type.name(), to_type.name());
+    throw ConversionException(utils::demangle(from_type), utils::demangle(to_type));
     // mechanism
   }
 }

--- a/src/sparsebase/utils/exception.h
+++ b/src/sparsebase/utils/exception.h
@@ -31,6 +31,22 @@ public:
   virtual const char *what() const throw() { return msg_.c_str(); }
 };
 
+class DemangleException : public Exception {
+  int status_;
+
+public:
+  DemangleException(int status) : status_(status) {}
+  virtual const char *what() const throw() {
+    if(status_ == -1){
+      return "A memory allocation failiure occurred.";
+    } else if(status_ == -2){
+      return "mangled_name is not a valid name under the C++ ABI mangling rules.";
+    } else {
+      return "Unknown failure in demangling.";
+    }
+  }
+};
+
 class ReaderException : public Exception {
   std::string msg_;
 
@@ -52,7 +68,7 @@ class TypeException : public Exception {
 
 public:
   TypeException(const std::string& msg) : msg_(msg) {}
-  TypeException(const std::string type1, const std::string type2)
+  TypeException(const std::string& type1, const std::string& type2)
       : msg_("Object is of type " + type1 + " not " + type2) {}
   virtual const char *what() const throw() { return msg_.c_str(); }
 };
@@ -61,7 +77,7 @@ class ConversionException : public Exception {
   std::string msg_;
 
 public:
-  ConversionException(const std::string type1, const std::string type2)
+  ConversionException(const std::string& type1, const std::string& type2)
       : msg_("Can not convert type " + type1 + " to " + type2) {}
   virtual const char *what() const throw() { return msg_.c_str(); }
 };

--- a/src/sparsebase/utils/utils.cc
+++ b/src/sparsebase/utils/utils.cc
@@ -1,0 +1,22 @@
+#include "utils.h"
+#include "exception.h"
+#include <cxxabi.h>
+
+namespace sparsebase::utils {
+    std::string demangle(const std::string& name) {
+      int status;
+      char *res = abi::__cxa_demangle(name.c_str(), NULL, NULL, &status);
+      if (status != 0) {
+        throw utils::DemangleException(status);
+      }
+
+      std::string res_str = res;
+      free(res);
+      return res_str;
+    }
+
+    std::string demangle(std::type_index type){
+      return demangle(type.name());
+    }
+}
+

--- a/src/sparsebase/utils/utils.h
+++ b/src/sparsebase/utils/utils.h
@@ -1,0 +1,28 @@
+/*******************************************************
+ * Copyright (c) 2022 SparCity, Amro Alabsi Aljundi, Taha Atahan Akyildiz, Arda Sener
+ * All rights reserved.
+ *
+ * This file is distributed under MIT license.
+ * The complete license agreement can be obtained at:
+ * https://sparcityeu.github.io/sparsebase/pages/license.html
+ ********************************************************/
+#ifndef SPARSEBASE_SPARSEBASE_UTILS_H_
+#define SPARSEBASE_SPARSEBASE_UTILS_H_
+
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+
+namespace sparsebase::utils {
+
+std::string demangle(const std::string& name);
+
+std::string demangle(std::type_index type);
+
+}
+
+#ifdef _HEADER_ONLY
+#include "sparsebase/utils/utils.cc"
+#endif
+
+#endif

--- a/tests/suites/sparsebase/format/format_tests.cc
+++ b/tests/suites/sparsebase/format/format_tests.cc
@@ -434,3 +434,57 @@ TEST(CSR, Sort) {
     EXPECT_EQ(csr3.get_col()[i], csr_col[i]);
   }
 }
+
+TEST(FormatImplementation, FormatID){
+
+  // Same Format type with different template parameters
+  // should have a different id
+  std::type_index id_csriii = format::CSR<int,int,int>::get_format_id_static();
+  std::type_index id_csriif = format::CSR<int,int,float>::get_format_id_static();
+  EXPECT_NE(id_csriii, id_csriif);
+
+  // Different Format types should have different ids
+  std::type_index id_cooiii = format::COO<int,int,int>::get_format_id_static();
+  EXPECT_NE(id_csriii, id_cooiii);
+
+
+  int csr_row_ptr[5]{0, 2, 3, 3, 4};
+  int csr_col[4]{2, 0, 1, 3};
+  sparsebase::format::CSR<int, int, int> csr(4, 4, csr_row_ptr,
+                                              csr_col, nullptr,
+                                              sparsebase::format::kNotOwned);
+
+  // If the Format type and templates are the same
+  // both the static and non-static function should give the same id
+  std::type_index id_csriii_obj = csr.get_format_id();
+  EXPECT_EQ(id_csriii, id_csriii_obj);
+
+}
+
+TEST(FormatImplementation, FormatName){
+  // Same Format type with different template parameters
+  // should have a different id
+  std::string name_csriii = format::CSR<int,int,int>::get_format_name_static();
+  std::string name_csriif = format::CSR<int,int,float>::get_format_name_static();
+  EXPECT_NE(name_csriii, name_csriif);
+
+  // Different Format types should have different ids
+  std::string name_cooiii = format::COO<int,int,int>::get_format_name_static();
+  EXPECT_NE(name_csriii, name_cooiii);
+
+
+  int csr_row_ptr[5]{0, 2, 3, 3, 4};
+  int csr_col[4]{2, 0, 1, 3};
+  sparsebase::format::CSR<int, int, int> csr(4, 4, csr_row_ptr,
+                                              csr_col, nullptr,
+                                              sparsebase::format::kNotOwned);
+
+  // If the Format type and templates are the same
+  // both the static and non-static function should give the same id
+  std::string name_csriii_obj = csr.get_format_name();
+  EXPECT_EQ(name_csriii, name_csriii_obj);
+
+  std::string name_csriii_mangled = csr.get_format_id().name();
+  EXPECT_NE(name_csriii, name_csriii_mangled);
+
+}


### PR DESCRIPTION
This PR is related to #169. 

## Changes

- New `utils.h` and `utils.cc` files in the utils namespace.
- `utils::demangle` function which takes a string or type_index representing a C++ type and converts it to a more human-readable string.
- `get_format_name()` and `get_format_name_static()` functions to `FormatImplementation` which return human-readable strings representing the concrete Format class.
- Some relevant tests. 
- Changes to some exception throws, to use the demangled names. I didn't change all of them mainly because they are a bit more complicated (for example `DirectExecutionNotAvailableException`). Furthermore, there are some other places where type names are used (for example `src/feature/feature.cc` has some `cout` statements). Many of these could be fixed overtime in other PRs.

## Example

```cpp
// Mangled name
N10sparsebase6format3CSRIiiiEE

// Demangled name
sparsebase::format::CSR<int, int, int>
```

## Compatibility

To handle demangling, the `__cxa_demangle` function is used. This is part of the `cxxabi.h` header which is not present on all platforms. However, in my tests, it was present when using `gcc` on both Linux and Windows (through MinGW). Furthermore, reportedly `clang` also includes the header. The only likely incompatibility is `msvc` which we officially do not support.  If we ever decide to add support, we can fix or disable this feature using some `ifdef` statements.