### PR TITLE
Fixed CUDA compilation and added auto architecture detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 project( SparseBase_project VERSION 0.2.4 )
 option(RUN_TESTS "Enable running tests" OFF)
 option(_HEADER_ONLY "Use the library as a header only library?" OFF)
-option(CUDA "Enable CUDA" OFF)
+option(USE_CUDA "Enable CUDA" OFF)
 option(USE_PIGO "Use PIGO for parallel I/O" ON)
 option(BUILD_EXAMPLES "Build example codes" ON)
 set(ID_TYPES "unsigned int" "int" CACHE STRING "C++ data types used for variables storing IDs")
@@ -18,14 +18,24 @@ set(VALUE_TYPES "unsigned int" "int" "float" "double" CACHE STRING "C++ data typ
 set(FLOAT_TYPES "float" "double" CACHE STRING "C++ data types used for variables storing floating point numbers")
 
 
-if(${CUDA})
+if(${USE_CUDA})
   if (${CMAKE_VERSION} VERSION_LESS "3.18")
     message(FATAL_ERROR "Using CUDA requires CMake version 3.18 or higher")
   endif()
   enable_language(CUDA)
   set(CMAKE_CUDA_STANDARD 17)
   set(CMAKE_CUDA_STANDARD_REQUIRED TRUE)
-  set(CMAKE_CUDA_ARCHITECTURES 60 62 70 75)
+
+  include(FindCUDA/select_compute_arch)
+  cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS_RAW Auto)
+  string(REGEX MATCHALL "[0-9][0-9]" CUDA_ARCHS ${CUDA_ARCH_FLAGS_RAW})
+  set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCHS})
+  # The four lines above figure out the architectures of CUDA for the GPUs in
+  # this system automatically. Technically, using FindCuda is deprecated.
+  # However, there is no modern CMAKE alternative until CMake 3.24:
+  # https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html#prop_tgt:CUDA_ARCHITECTURES
+  # If CMake is upgraded to 3.24, the above four lines will be replaced by
+  # set(CMAKE_CUDA_ARCHITECTURES native)
 endif()
 if (WIN32 OR APPLE)
   message(STATUS "PIGO is not supported on Windows and MacOS at the moment.")

--- a/docs/pages/contributing/testing_guide.md
+++ b/docs/pages/contributing/testing_guide.md
@@ -231,7 +231,7 @@ If there is a certain test file that is conditional on a CMake option, then you 
 
 For example, the test file `tests/suites/sparsebase/preprocess/cuda/preprocess_tests.cu` should only be added when the library is compiled with the `CUDA` option enabled. Here is how we define its executable and tests in the file `tests/suites/sparsebase/preprocess/cuda/CMakeLists.txt`:
 ```CMake
-if(${CUDA})
+if(${USE_CUDA})
     add_executable(sparsebase__preprocess_cuda_preprocess_tests.test preprocess_tests.cu)
     target_link_libraries(sparsebase_preprocess_cuda_preprocess_tests.test sparsebase)
     target_link_libraries(sparsebase_preprocess_cuda_preprocess_tests.test gtest gtest_main)
@@ -249,7 +249,7 @@ For example, if a certain test is only required when the library is compiled wit
 ```C++
 #include "sparsebase/config.h"
 
-#ifdef CUDA
+#ifdef USE_CUDA
 TEST(CudaTestSuite, CudaInitialization){
   // code
 }

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -31,7 +31,7 @@ We suggest using the most recent versions when possible.
 
 ```bash
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCUDA={$CUDA} ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA={$CUDA} ..
 make
 ```
 Where `${CUDA}` is `ON` if CUDA support is needed and `OFF` otherwise.
@@ -62,7 +62,7 @@ Alternatively, you can edit the `CMakeCache.txt` file located in the build direc
 Additionally, the library has a header-only setting, in which none of the classes of the library will be explicitly instantiated at library-build time. Building the library to be header-only can be done as shown:
 ```
 mkdir build && cd build
-cmake -D_HEADER_ONLY=ON -DCMAKE_BUILD_TYPE=Release -DCUDA=${CUDA} ..
+cmake -D_HEADER_ONLY=ON -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=${CUDA} ..
 make
 ```
 Where `${CUDA}` is `ON` if CUDA support is needed and `OFF` otherwise.

--- a/docs/pages/how_to_guides/how_add_reordering.md
+++ b/docs/pages/how_to_guides/how_add_reordering.md
@@ -159,7 +159,7 @@ OptimalOrderCSRonCUDAGPUDriver(format::CUDACSR<IDType, NNZType, ValueType> *csr,
 ```
 
 
-Finally, we add the function `OptimallyReorderCUDACSR()` as an implementation inside the `OptimalReorder` class. Note that the function is enclosed in an `#ifdef CUDA` preprocessor block. This will guarantee that it does not get compiled unless compilation of the library with `CUDA` is enabled.
+Finally, we add the function `OptimallyReorderCUDACSR()` as an implementation inside the `OptimalReorder` class. Note that the function is enclosed in an `#ifdef USE_CUDA` preprocessor block. This will guarantee that it does not get compiled unless compilation of the library with `CUDA` is enabled.
 
 ```cpp
 // File: src/sparsebase/preprocess/preprocess.h
@@ -167,7 +167,7 @@ namespace sparsebase::preprocess {
 template <typename IDType, typename NNZType, typename ValueType>
 class OptimalReorder : ReorderPreprocessType<IDType, NNZType, ValueType> {
 // We do not want the function to be compiled if CUDA isn't enabled
-#ifdef CUDA
+#ifdef USE_CUDA
   static IDType *OptimallyOrderCUDACSR(
       std::vector<format::Format<IDType, NNZType, ValueType> *> input_sf,
       PreprocessParams *poly_params) {
@@ -192,7 +192,7 @@ class OptimalReorder : ReorderPreprocessType<IDType, NNZType, ValueType> {
 
 ### 4. Register the implementations you wrote to the correct formats
 
-Inside the constructor, register the functions you made to the correct `Format` type. Note that registering the `CUDACSR` implementation function is surrounded by an `#ifdef CUDA` block to prevent it from being registered if the library is not compiled with `CUDA` enabled.
+Inside the constructor, register the functions you made to the correct `Format` type. Note that registering the `CUDACSR` implementation function is surrounded by an `#ifdef USE_CUDA` block to prevent it from being registered if the library is not compiled with `CUDA` enabled.
 
 ```cpp
 // File: src/sparsebase/preprocess/preprocess.h
@@ -205,7 +205,7 @@ class OptimalReorder : ReorderPreprocessType<IDType, NNZType, ValueType> {
     this->RegisterFunction(
         {format::CSR<IDType, NNZType, ValueType>::get_format_id_static()},
         OptimallyOrderCSR);
-#ifdef CUDA
+#ifdef USE_CUDA
     this->RegisterFunction(
         {format::CUDACSR<IDType, NNZType, ValueType>::get_format_id_static()},
         OptimallyOrderCUDACSR);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,11 +6,11 @@ configure_file(
 
 file(COPY ${CMAKE_SOURCE_DIR}/examples/data DESTINATION ${CMAKE_BINARY_DIR}/examples/)
 
-if (${CUDA})
+if (${USE_CUDA})
   add_subdirectory(cuda_example)
   add_subdirectory(array_example)
 endif()
-if(NOT ${_HEADER_ONLY} OR NOT ${CUDA})
+if(NOT ${_HEADER_ONLY} OR NOT ${USE_CUDA})
   add_subdirectory(csr_coo)
   add_subdirectory(degree_order)
   add_subdirectory(custom_order)

--- a/examples/array_example/array_example.cu
+++ b/examples/array_example/array_example.cu
@@ -37,7 +37,7 @@ int main() {
                              cuda_array->get_dimensions()[0]);
   cudaDeviceSynchronize();
 
-  auto cpu_array->Convert<format::Array>(&cpu_context);
+  auto cpu_array = cuda_array->Convert<format::Array>(&cpu_context);
 
   print_array(cpu_array->get_vals(), cuda_array->get_dimensions()[0]);
 

--- a/examples/cuda_example/cuda_example.cu
+++ b/examples/cuda_example/cuda_example.cu
@@ -59,7 +59,7 @@ int main() {
   auto array_converter = new utils::converter::ConverterOrderOne<float>();
 
   preprocess::JaccardWeights<int, int, int, float> jac;
-  auto array = jac.GetJaccardWeights({csr}, {&gpu_context, &cpu_context});
+  auto array = jac.GetJaccardWeights({csr}, {&gpu_context, &cpu_context}, true);
 
   if (array->get_context_type() == context::CPUContext::get_context_type()) {
     auto cpu_array =

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT ${_HEADER_ONLY})
     --value-types ${VALUE_TYPES_JOINED} 
     --float-types ${FLOAT_TYPES_JOINED}
     --pigo ${USE_PIGO}
-    --cuda ${CUDA}
+    --cuda ${USE_CUDA}
     --output-folder ${PROJECT_BINARY_DIR}/init)
   message(STATUS "Generated explicit instantiations")
   set(LIB_FILES
@@ -27,7 +27,7 @@ if(NOT ${_HEADER_ONLY})
     sparsebase/feature/feature.cc
     sparsebase/utils/io/writer.cc
   )
-  if (${CUDA})
+  if (${USE_CUDA})
 
     set(LIB_FILES ${LIB_FILES}
       sparsebase/format/cuda/format.cu
@@ -217,7 +217,7 @@ install(FILES
   sparsebase/external/json/json.hpp
   DESTINATION include/sparsebase/external/json/)
 
-if(${CUDA})
+if(${USE_CUDA})
   set(CUDA_FORMAT_FILES
     sparsebase/format/cuda/format.cuh)
   set(CUDA_CONVERTER_FILES

--- a/src/generate_explicit_instantiations.py
+++ b/src/generate_explicit_instantiations.py
@@ -39,7 +39,7 @@ def reset_file(filename, folder=output_folder):
     out.close()
 
 
-def gen_inst(template, filename, ifdef=None, folder=output_folder):
+def gen_inst(template, filename, is_class=True, ifdef=None, folder=output_folder):
 
     out = sys.stdout
     if not dry_run:
@@ -61,7 +61,11 @@ def gen_inst(template, filename, ifdef=None, folder=output_folder):
 
         if key not in already_added:
             already_added.add(key)
-            out.write("template class " + inst + ";\n")
+            if is_class:
+                out.write("template class " + inst + ";\n")
+            else:
+                out.write("template  " + inst + ";\n")
+
 
     if ifdef is not None:
         out.write("#endif\n")
@@ -84,13 +88,13 @@ gen_inst("Array<$id_type>", "format.inc")
 # Format (CUDA)
 reset_file("format.inc", cuda_output_folder)
 gen_inst("CUDACSR<$id_type, $nnz_type, $value_type>", "format.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
+         ifdef="USE_CUDA", folder=cuda_output_folder)
 gen_inst("CUDAArray<$value_type>", "format.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
+         ifdef="USE_CUDA", folder=cuda_output_folder)
 gen_inst("CUDAArray<$id_type>", "format.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
+         ifdef="USE_CUDA", folder=cuda_output_folder)
 gen_inst("CUDAArray<$nnz_type>", "format.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
+         ifdef="USE_CUDA", folder=cuda_output_folder)
 
 
 # Object
@@ -116,16 +120,16 @@ order_one_functions = ['CUDAArrayArrayConditionalFunction',
                        'ArrayCUDAArrayConditionalFunction']
 
 for func in order_two_functions:
-    gen_inst(return_type + func + "<$id_type, $nnz_type, $value_type>" + params, "converter.inc",
-             ifdef="CUDA", folder=cuda_output_folder)
+    gen_inst(return_type + func + "<$id_type, $nnz_type, $value_type>" + params, "converter.inc", is_class=False,
+             ifdef="USE_CUDA", folder=cuda_output_folder)
 
 for func in order_one_functions:
-    gen_inst(return_type + func + "<$id_type>" + params, "converter.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
-    gen_inst(return_type + func + "<$nnz_type>" + params, "converter.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
-    gen_inst(return_type + func + "<$value_type>" + params, "converter.inc",
-         ifdef="CUDA", folder=cuda_output_folder)
+    gen_inst(return_type + func + "<$id_type>" + params, "converter.inc", is_class=False,
+         ifdef="USE_CUDA", folder=cuda_output_folder)
+    gen_inst(return_type + func + "<$nnz_type>" + params, "converter.inc", is_class=False,
+         ifdef="USE_CUDA", folder=cuda_output_folder)
+    gen_inst(return_type + func + "<$value_type>" + params, "converter.inc", is_class=False,
+         ifdef="USE_CUDA", folder=cuda_output_folder)
 
 
 
@@ -180,7 +184,8 @@ gen_inst("PartitionPreprocessType<$id_type>", "preprocess.inc")
 # Preprocess (CUDA)
 reset_file("preprocess.inc", cuda_output_folder)
 gen_inst("format::cuda::CUDAArray<$float_type>* "
-         + "RunJaccardKernel(format::cuda::CUDACSR<$id_type, $nnz_type, $value_type>*)",
+         + "RunJaccardKernel<$id_type, $nnz_type, $value_type, $float_type>(format::cuda::CUDACSR<$id_type, $nnz_type, $value_type>*)",
          "preprocess.inc",
+         is_class=False,
          ifdef="USE_CUDA",
          folder=cuda_output_folder)

--- a/src/sparsebase/config.h.in
+++ b/src/sparsebase/config.h.in
@@ -2,7 +2,7 @@
 #define SPARSEBASE_CONFIG_H_
 
 #cmakedefine _HEADER_ONLY
-#cmakedefine CUDA
+#cmakedefine USE_CUDA
 #cmakedefine USE_PIGO
 #cmakedefine USE_METIS
 

--- a/src/sparsebase/context/cuda/context.cu
+++ b/src/sparsebase/context/cuda/context.cu
@@ -3,6 +3,7 @@
 //
 #include "sparsebase/context/context.h"
 #include "sparsebase/context/cuda/context.cuh"
+#include "sparsebase/utils/exception.h"
 namespace sparsebase {
 namespace context {
 namespace cuda {

--- a/src/sparsebase/context/cuda/context.cuh
+++ b/src/sparsebase/context/cuda/context.cuh
@@ -9,7 +9,6 @@
 #ifndef SPARSEBASE_SPARSEBASE_CONTEXT_CUDA_CONTEXT_H_
 #define SPARSEBASE_SPARSEBASE_CONTEXT_CUDA_CONTEXT_H_
 
-#include "sparsebase/format/format.h"
 namespace sparsebase {
 namespace context {
 namespace cuda {

--- a/src/sparsebase/format/cuda/format.cuh
+++ b/src/sparsebase/format/cuda/format.cuh
@@ -6,9 +6,9 @@
  * The complete license agreement can be obtained at:
  * https://sparcityeu.github.io/sparsebase/pages/license.html
  ********************************************************/
+#include "sparsebase/format/format.h"
 #include "sparsebase/context/context.h"
 #include "sparsebase/context/cuda/context.cuh"
-#include "sparsebase/format/format.h"
 #ifndef SPARSEBASE_SPARSEBASE_FORMAT_CUDA_FORMAT_H_
 #define SPARSEBASE_SPARSEBASE_FORMAT_CUDA_FORMAT_H_
 

--- a/src/sparsebase/format/format.h
+++ b/src/sparsebase/format/format.h
@@ -412,7 +412,7 @@ FormatOrderTwo<IDType, NNZType, ValueType>::Convert(
 } // namespace sparsebase
 #ifdef _HEADER_ONLY
 #include "sparsebase/format/format.cc"
-#ifdef CUDA
+#ifdef USE_CUDA
 #include "cuda/format.cu"
 #endif
 #endif

--- a/src/sparsebase/preprocess/preprocess.cc
+++ b/src/sparsebase/preprocess/preprocess.cc
@@ -1,7 +1,7 @@
 #include "preprocess.h"
 #include "sparsebase/format/format.h"
 #include "sparsebase/utils/converter/converter.h"
-#ifdef CUDA
+#ifdef USE_CUDA
 #include "sparsebase/preprocess/cuda/preprocess.cuh"
 #endif
 #include <iostream>
@@ -706,7 +706,7 @@ template <typename IDType, typename NNZType, typename ValueType,
 JaccardWeights<IDType, NNZType, ValueType, FeatureType>::JaccardWeights() {
   this->SetConverter(
       utils::converter::ConverterOrderTwo<IDType, NNZType, ValueType>{});
-#ifdef CUDA
+#ifdef USE_CUDA
   std::vector<std::type_index> formats = {
       format::cuda::CUDACSR<IDType, NNZType,
                             ValueType>::get_format_id_static()};
@@ -726,7 +726,7 @@ JaccardWeights<IDType, NNZType, ValueType, FeatureType>::GetJaccardWeights(
   return this->Execute(nullptr, (this->sc_.get()), contexts, convert_input,
                        format); // func(sfs, this->params_.get());
 }
-#ifdef CUDA
+#ifdef USE_CUDA
 template <typename IDType, typename NNZType, typename ValueType,
           typename FeatureType>
 format::Format *

--- a/src/sparsebase/preprocess/preprocess.h
+++ b/src/sparsebase/preprocess/preprocess.h
@@ -627,7 +627,7 @@ public:
    */
   format::Format *GetJaccardWeights(format::Format *format,
                                     std::vector<context::Context *>, bool convert_input);
-#ifdef CUDA
+#ifdef USE_CUDA
   //! Take a CUDACSR representating a graph and get the Jaccard Weights as a
   //! CUDAArray
   /*!
@@ -1049,7 +1049,7 @@ int tester(typename Reordering<IDType, NNZType, ValueType>::ParamsType params){
 } // namespace sparsebase::preprocess
 #ifdef _HEADER_ONLY
 #include "sparsebase/preprocess/preprocess.cc"
-#ifdef CUDA
+#ifdef USE_CUDA
 #include "cuda/preprocess.cu"
 #endif
 #endif

--- a/src/sparsebase/sparsebase.h
+++ b/src/sparsebase/sparsebase.h
@@ -18,7 +18,7 @@
 #include "sparsebase/utils/io/reader.h"
 #include "sparsebase/utils/io/iobase.h"
 #include "sparsebase/utils/io/writer.h"
-#ifdef CUDA
+#ifdef USE_CUDA
 #include "sparsebase/context/cuda/context.cuh"
 #include "sparsebase/format/cuda/format.cuh"
 #include "sparsebase/preprocess/cuda/preprocess.cuh"

--- a/src/sparsebase/utils/converter/converter.cc
+++ b/src/sparsebase/utils/converter/converter.cc
@@ -1,5 +1,5 @@
-#include "sparsebase/utils/converter/converter.h"
 #include "sparsebase/format/format.h"
+#include "sparsebase/utils/converter/converter.h"
 #include <iostream>
 #include <set>
 
@@ -272,7 +272,7 @@ Converter *ConverterOrderOne<ValueType>::Clone() const {
 }
 
 template <typename ValueType> void ConverterOrderOne<ValueType>::Reset() {
-#ifdef CUDA
+#ifdef USE_CUDA
   this->RegisterConditionalConversionFunction(
       Array<ValueType>::get_format_id_static(),
       format::cuda::CUDAArray<ValueType>::get_format_id_static(),
@@ -318,7 +318,7 @@ void ConverterOrderTwo<IDType, NNZType, ValueType>::Reset() {
       CSC<IDType, NNZType, ValueType>::get_format_id_static(),
       CsrCscFunctionConditional<IDType, NNZType, ValueType>,
       [](context::Context *, context::Context *) -> bool { return true; });
-#ifdef CUDA
+#ifdef USE_CUDA
   this->RegisterConditionalConversionFunction(
       format::cuda::CUDACSR<IDType, NNZType, ValueType>::get_format_id_static(),
       format::cuda::CUDACSR<IDType, NNZType, ValueType>::get_format_id_static(),

--- a/src/sparsebase/utils/converter/converter.h
+++ b/src/sparsebase/utils/converter/converter.h
@@ -13,7 +13,7 @@
 #include <functional>
 #include <tuple>
 #include <unordered_map>
-#ifdef CUDA
+#ifdef USE_CUDA
 #include "sparsebase/format/cuda/format.cuh"
 #include "sparsebase/utils/converter/cuda/converter.cuh"
 #endif
@@ -207,7 +207,7 @@ public:
 } // namespace sparsebase
 #ifdef _HEADER_ONLY
 #include "sparsebase/utils/converter/converter.cc"
-#ifdef CUDA
+#ifdef USE_CUDA
 #include "cuda/converter.cu"
 #endif
 #endif

--- a/tests/suites/sparsebase/preprocess/cuda/CMakeLists.txt
+++ b/tests/suites/sparsebase/preprocess/cuda/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(${CUDA})
+if(${USE_CUDA})
     add_executable(preprocess_cuda_preprocess_tests.test preprocess_tests.cu)
     target_link_libraries(preprocess_cuda_preprocess_tests.test sparsebase)
     target_link_libraries(preprocess_cuda_preprocess_tests.test gtest gtest_main)

--- a/tests/suites/sparsebase/preprocess/cuda/preprocess_tests.cu
+++ b/tests/suites/sparsebase/preprocess/cuda/preprocess_tests.cu
@@ -25,11 +25,13 @@ sparsebase::context::CPUContext cpu_context;
 TEST(JaccardTest, Jaccard) {
   sparsebase::preprocess::JaccardWeights<int, int, int, float> jac;
   context::cuda::CUDAContext gpu_context(0);
-  auto jac_array = jac.GetJaccardWeights(&global_csr, {&gpu_context});
+  auto jac_array = jac.GetJaccardWeights(&global_csr, {&gpu_context}, true);
   EXPECT_EQ(jac_array->get_format_id(),
             format::cuda::CUDAArray<float>::get_format_id_static());
   utils::converter::ConverterOrderOne<float> converter;
   auto jac_cpu_array =
       converter.Convert<format::Array<float>>(jac_array, {&gpu_context});
   EXPECT_EQ(jac_cpu_array->get_dimensions()[0], 4);
+  EXPECT_THROW(jac.GetJaccardWeights(&global_csr, {&cpu_context}, false),
+               utils::DirectExecutionNotAvailableException<std::vector<std::type_index>>);
 }

--- a/tests/suites/sparsebase/preprocess/preprocess_tests.cc
+++ b/tests/suites/sparsebase/preprocess/preprocess_tests.cc
@@ -750,7 +750,7 @@ TEST(PermuteTest, NoConversionNoParamCached) {
   ASSERT_EQ(std::get<0>(transformed_output)[0], nullptr);
 }
 
-#ifndef CUDA
+#ifndef USE_CUDA
 TEST(JaccardTest, NoCuda) {
   sparsebase::preprocess::JaccardWeights<int, int, int, float> jac;
   EXPECT_THROW(jac.GetJaccardWeights(&global_csr, {&cpu_context}, true),


### PR DESCRIPTION
Fixed a problem with CUDA compilation due to bad include ordering + using USE_CUDA instead of CUDA in explicit generation scripts. Also added automatic detection of CUDA architectures on the system.

Changes:
1. Changed the flag `CUDA` to `USE_CUDA` to be more inline with the rest of the library.
2. Flipped the order of including `format.h` and `converter.h` in `format.cuh`.
3. included `exception.h` in `context.cu`
4. Added to CMakeLists.txt ability to detect architectures automatically. The method uses a deprecated function, but the "modern" way is only available in CMake 3.24.