### PR TITLE
Logger

### DIFF
--- a/src/sparsebase/format/format.cc
+++ b/src/sparsebase/format/format.cc
@@ -7,6 +7,7 @@
 #include "sparsebase/format/format.h"
 #include "sparsebase/utils/converter/converter.h"
 #include "sparsebase/utils/exception.h"
+#include "sparsebase/utils/utils.h"
 
 using namespace sparsebase::utils;
 
@@ -118,7 +119,9 @@ COO<IDType, NNZType, ValueType>::COO(IDType n, IDType m, NNZType nnz,
   }
 
   if (not_sorted) {
-    std::cerr << "COO arrays must be sorted. Sorting..." << std::endl;
+    utils::Logger logger(typeid(this));
+    logger.Log("COO arrays must be sorted. Sorting...", utils::LOG_LVL_INFO);
+
     if constexpr (std::is_same_v<ValueType, void>){
       std::vector<std::pair<IDType, IDType>> sort_vec;
       for (DimensionType i = 0; i < nnz; i++) {
@@ -386,7 +389,9 @@ CSR<IDType, NNZType, ValueType>::CSR(IDType n, IDType m, NNZType *row_ptr,
     }
 
     if (not_sorted) {
-      std::cerr << "CSR column array must be sorted. Sorting..." << std::endl;
+      utils::Logger logger(typeid(this));
+      logger.Log("CSR column array must be sorted. Sorting...", utils::LOG_LVL_INFO);
+
 
 #pragma omp parallel for default(none) shared(row_ptr, col, vals, n)
       for (IDType i = 0; i < n; i++) {
@@ -634,7 +639,8 @@ CSC<IDType, NNZType, ValueType>::CSC(IDType n, IDType m, NNZType *col_ptr,
     }
 
     if (not_sorted) {
-      std::cerr << "CSR column array must be sorted. Sorting..." << std::endl;
+      utils::Logger logger(typeid(this));
+      logger.Log("CSC column array must be sorted. Sorting...", utils::LOG_LVL_INFO);
 
 #pragma omp parallel for default(none) shared(col_ptr, row, vals, n)
       for (IDType i = 0; i < n; i++) {

--- a/src/sparsebase/format/format.cc
+++ b/src/sparsebase/format/format.cc
@@ -120,7 +120,7 @@ COO<IDType, NNZType, ValueType>::COO(IDType n, IDType m, NNZType nnz,
 
   if (not_sorted) {
     utils::Logger logger(typeid(this));
-    logger.Log("COO arrays must be sorted. Sorting...", utils::LOG_LVL_INFO);
+    logger.Log("COO arrays must be sorted. Sorting...", utils::LOG_LVL_WARNING);
 
     if constexpr (std::is_same_v<ValueType, void>){
       std::vector<std::pair<IDType, IDType>> sort_vec;
@@ -390,7 +390,7 @@ CSR<IDType, NNZType, ValueType>::CSR(IDType n, IDType m, NNZType *row_ptr,
 
     if (not_sorted) {
       utils::Logger logger(typeid(this));
-      logger.Log("CSR column array must be sorted. Sorting...", utils::LOG_LVL_INFO);
+      logger.Log("CSR column array must be sorted. Sorting...", utils::LOG_LVL_WARNING);
 
 
 #pragma omp parallel for default(none) shared(row_ptr, col, vals, n)
@@ -640,7 +640,7 @@ CSC<IDType, NNZType, ValueType>::CSC(IDType n, IDType m, NNZType *col_ptr,
 
     if (not_sorted) {
       utils::Logger logger(typeid(this));
-      logger.Log("CSC column array must be sorted. Sorting...", utils::LOG_LVL_INFO);
+      logger.Log("CSC column array must be sorted. Sorting...", utils::LOG_LVL_WARNING);
 
 #pragma omp parallel for default(none) shared(col_ptr, row, vals, n)
       for (IDType i = 0; i < n; i++) {

--- a/src/sparsebase/utils/utils.cc
+++ b/src/sparsebase/utils/utils.cc
@@ -1,6 +1,9 @@
 #include "utils.h"
 #include "exception.h"
 #include <cxxabi.h>
+#include <algorithm>
+#include <sstream>
+#include <ctime>
 
 namespace sparsebase::utils {
     std::string demangle(const std::string& name) {
@@ -19,9 +22,55 @@ namespace sparsebase::utils {
       return demangle(type.name());
     }
 
-    LogLevel Logger::level = LOG_LVL_WARNING;
-    std::string Logger::filename;
-    bool Logger::use_stdout = true;
-    bool Logger::use_stderr = false;
+    Logger::Logger(std::type_index root_type) {
+      root_ = demangle(root_type);
+      root_.erase(std::remove(root_.begin(), root_.end(), '*'), root_.end());
+      if(!Logger::filename_.empty()) file_.open(filename_);
+    }
+
+    Logger::Logger() {
+      if(!Logger::filename_.empty()) file_.open(filename_);
+    }
+
+    Logger::~Logger(){
+      if(file_.is_open()) file_.close();
+    }
+
+    void Logger::Log(const std::string& message, LogLevel msg_level){
+
+      if(msg_level < Logger::level_){
+        return;
+      }
+
+      std::time_t current = std::time(0);
+      auto now_tm = std::localtime(&current);
+      char buffer[30];
+      size_t size = strftime(buffer, 30, "%x %X", now_tm);
+      std::string now_str(buffer, buffer + size);
+
+      std::stringstream ss;
+      ss << "[" << now_str << "]" << " ";
+
+      std::string level_str = "INFO";
+      if(msg_level == LOG_LVL_WARNING){
+        level_str = "WARNING";
+      }
+      ss << "[" << level_str << "]" << " ";
+
+      ss << "[" << root_ << "]" << " ";
+
+      ss << message;
+
+      std::string log = ss.str();
+
+      if(file_.is_open()) file_ << log << std::endl;
+      if(Logger::use_stdout_) std::cout << log << std::endl;
+      if(Logger::use_stderr_) std::cerr << log << std::endl;
+    }
+
+    LogLevel Logger::level_ = LOG_LVL_WARNING;
+    std::string Logger::filename_;
+    bool Logger::use_stdout_ = true;
+    bool Logger::use_stderr_ = false;
 }
 

--- a/src/sparsebase/utils/utils.cc
+++ b/src/sparsebase/utils/utils.cc
@@ -18,5 +18,10 @@ namespace sparsebase::utils {
     std::string demangle(std::type_index type){
       return demangle(type.name());
     }
+
+    LogLevel Logger::level = LOG_LVL_WARNING;
+    std::string Logger::filename;
+    bool Logger::use_stdout = true;
+    bool Logger::use_stderr = false;
 }
 

--- a/src/sparsebase/utils/utils.h
+++ b/src/sparsebase/utils/utils.h
@@ -16,9 +16,7 @@
 #include <cstdint>
 #include "exception.h"
 #include <fstream>
-#include <algorithm>
-#include <sstream>
-#include <ctime>
+
 
 namespace sparsebase::utils {
 
@@ -162,77 +160,37 @@ class Logger {
 
 private:
 
-  std::string root;
-  static LogLevel level;
-  static bool use_stdout;
-  static bool use_stderr;
-  static std::string filename;
-  std::ofstream file;
-
-
+  std::string root_;
+  static LogLevel level_;
+  static bool use_stdout_;
+  static bool use_stderr_;
+  static std::string filename_;
+  std::ofstream file_;
 
 public:
-  Logger() {
-    if(!Logger::filename.empty()) file.open(filename);
+  Logger();
+
+  Logger(std::type_index root_type);
+
+  ~Logger();
+
+  static void set_level(LogLevel level){
+    Logger::level_ = level;
   }
 
-  Logger(std::type_index root_type) {
-    root = demangle(root_type);
-    root.erase(std::remove(root.begin(), root.end(), '*'), root.end());
-    if(!Logger::filename.empty()) file.open(filename);
+  static void set_stdout(bool use){
+    Logger::use_stdout_ = use;
   }
 
-  ~Logger(){
-    if(file.is_open()) file.close();
+  static void set_stderr(bool use){
+    Logger::use_stderr_ = use;
   }
 
-  static void SetLogLevel(LogLevel new_level){
-    Logger::level = new_level;
+  static void set_file(const std::string& filename){
+    Logger::filename_ = filename;
   }
 
-  static void SetStdOut(bool use){
-    Logger::use_stdout = use;
-  }
-
-  static void SetStdErr(bool use){
-    Logger::use_stderr = use;
-  }
-
-  static void SetFile(const std::string& new_filename){
-    Logger::filename = new_filename;
-  }
-
-  void Log(const std::string& message, LogLevel msg_level = LOG_LVL_INFO){
-
-    if(msg_level < Logger::level){
-      return;
-    }
-
-    std::time_t current = std::time(0);
-    auto now_tm = std::localtime(&current);
-    char buffer[30];
-    size_t size = strftime(buffer, 30, "%x %X", now_tm);
-    std::string now_str(buffer, buffer + size);
-
-    std::stringstream ss;
-    ss << "[" << now_str << "]" << " ";
-
-    std::string level_str = "INFO";
-    if(msg_level == LOG_LVL_WARNING){
-      level_str = "WARNING";
-    }
-    ss << "[" << level_str << "]" << " ";
-
-    ss << "[" << root << "]" << " ";
-
-    ss << message;
-
-    std::string log = ss.str();
-
-    if(file.is_open()) file << log << std::endl;
-    if(Logger::use_stdout) std::cout << log << std::endl;
-    if(Logger::use_stderr) std::cerr << log << std::endl;
-  }
+  void Log(const std::string& message, LogLevel msg_level = LOG_LVL_INFO);
 };
 
 }


### PR DESCRIPTION
This PR adds a `Logger` class to the `utils` namespace. 

The structure of the log messages is the following:

```
[TIME] [LEVEL] [SOURCE] MESSAGE
```

`TIME` is a date and time string. Note that this uses the locale so could differ from system to system.

`LEVEL` can be `INFO` or `WARNING`. Other levels can be easily added later if need be. Note that `ERROR` is not implemented as those should be exceptions instead. `DEBUG` is also not implemented as ideally that would be turned on/off in compile time; this could be implemented later as a separate function.

`SOURCE` will typically be the demangled class name however developers can customize it if needed.

Here is an example:
```
[10/21/22 00:10:51] [WARNING] [sparsebase::format::CSR<unsigned int, unsigned int, unsigned int>] CSR column array must be sorted. Sorting...
```


Developers can use the Logger as shown here:

```cpp
utils::Logger logger(typeid(this));
logger.Log("COO arrays must be sorted. Sorting...", utils::LOG_LVL_WARNING);
```

> Instead of `typeid(this)` the developer can also pass an arbitrary string. This is used to show the source field in the log message.

Users can adjust various aspects of the logging. Here is an example:

```cpp
// Doesn't log INFO level events
utils::Logger::set_level(utils::LOG_LVL_WARNING); 

// Write to file as well as print
utils::Logger::set_file("test.log");

// Use stderr instead of stdout
utils::Logger::set_stdout(false);
utils::Logger::set_stderr(true);
```
