### PR TITLE
Fix/degree reorder

### DIFF
--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -52,6 +52,9 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
       sorted[n - i - 1] = swp;
     }
   }*/
+  for (IDType u = 0; u < n; u++) {
+    sorted[u] = u;
+  }
   /* Create inverse permutation */
   auto *inverse_permutation = new IDType[n];
   for (IDType i = 0; i < n; i++) {

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -41,7 +41,7 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   IDType *mr = new IDType[n]();
   for (IDType u = 0; u < n; u++) {
     IDType ec = counts[row_ptr[u + 1] - row_ptr[u]];
-    sorted[ec - mr[ec] - 1] = u;
+    sorted[ec + mr[ec]] = u;
     mr[ec]++;
   }
   if (!ascending) {

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -26,24 +26,22 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   DegreeReorderParams *cast_params = static_cast<DegreeReorderParams *>(params);
   bool ascending = cast_params->ascending;
   IDType n = csr->get_dimensions()[0];
-  IDType *counts = new IDType[n + 1]();
+  IDType *counts = new IDType[n]();
   auto row_ptr = csr->get_row_ptr();
   auto col = csr->get_col();
-
-  /* Counting sort */
-  /*for (IDType u = 0; u < n; u++) {
-    counts[row_ptr[u + 1] - row_ptr[u]]++;
+  for (IDType u = 0; u < n; u++) {
+    counts[row_ptr[u + 1] - row_ptr[u] + 1]++;
   }
-  for (IDType u = 1; u < n + 1; u++) {
+  for (IDType u = 1; u < n; u++) {
     counts[u] += counts[u - 1];
-  }*/
+  }
   IDType *sorted = new IDType[n];
   memset(sorted, -1, sizeof(IDType) * n);
-  /*for (IDType u = 0; u < n; u++) {
-    IDType deg = row_ptr[u + 1] - row_ptr[u];
-    IDType ec = counts[deg];
-    counts[deg]--;
-    sorted[ec - 1] = u;
+  IDType *mr = new IDType[n]();
+  for (IDType u = 0; u < n; u++) {
+    IDType ec = counts[row_ptr[u + 1] - row_ptr[u]];
+    sorted[ec + mr[ec]] = u;
+    mr[ec]++;
   }
   if (!ascending) {
     for (IDType i = 0; i < n / 2; i++) {
@@ -51,16 +49,12 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
       sorted[i] = sorted[n - i - 1];
       sorted[n - i - 1] = swp;
     }
-  }*/
-  for (IDType u = 0; u < n; u++) {
-    sorted[u] = u;
   }
-  /* Create inverse permutation */
   auto *inverse_permutation = new IDType[n];
   for (IDType i = 0; i < n; i++) {
     inverse_permutation[sorted[i]] = i;
   }
-  
+  delete[] mr;
   delete[] counts;
   delete[] sorted;
   return inverse_permutation;

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -39,9 +39,10 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   memset(sorted, -1, sizeof(IDType) * n);
   IDType *mr = new IDType[n]();
   for (IDType u = 0; u < n; u++) {
-    IDType ec = counts[row_ptr[u + 1] - row_ptr[u]];
-    sorted[ec + mr[ec]] = u;
-    mr[ec]++;
+    IDType deg = row_ptr[u + 1] - row_ptr[u];
+    IDType ec = counts[deg];
+    counts[deg]--;
+    sorted[ec - 1] = u;
   }
   if (!ascending) {
     for (IDType i = 0; i < n / 2; i++) {

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -41,7 +41,7 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   IDType *mr = new IDType[n]();
   for (IDType u = 0; u < n; u++) {
     IDType ec = counts[row_ptr[u + 1] - row_ptr[u]];
-    sorted[ec + mr[ec]] = u;
+    sorted[ec - mr[ec] - 1] = u;
     mr[ec]++;
   }
   if (!ascending) {

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -55,7 +55,7 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   for (IDType i = 0; i < n; i++) {
     inverse_permutation[sorted[i]] = i;
   }
-  //delete[] mr;
+  delete[] mr;
   delete[] counts;
   delete[] sorted;
   return inverse_permutation;

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -31,15 +31,15 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   auto col = csr->get_col();
 
   /* Counting sort */
-  for (IDType u = 0; u < n; u++) {
+  /*for (IDType u = 0; u < n; u++) {
     counts[row_ptr[u + 1] - row_ptr[u]]++;
   }
   for (IDType u = 1; u < n + 1; u++) {
     counts[u] += counts[u - 1];
-  }
+  }*/
   IDType *sorted = new IDType[n];
   memset(sorted, -1, sizeof(IDType) * n);
-  for (IDType u = 0; u < n; u++) {
+  /*for (IDType u = 0; u < n; u++) {
     IDType deg = row_ptr[u + 1] - row_ptr[u];
     IDType ec = counts[deg];
     counts[deg]--;
@@ -51,7 +51,7 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
       sorted[i] = sorted[n - i - 1];
       sorted[n - i - 1] = swp;
     }
-  }
+  }*/
   /* Create inverse permutation */
   auto *inverse_permutation = new IDType[n];
   for (IDType i = 0; i < n; i++) {

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -55,7 +55,7 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   for (IDType i = 0; i < n; i++) {
     inverse_permutation[sorted[i]] = i;
   }
-  delete[] mr;
+  //delete[] mr;
   delete[] counts;
   delete[] sorted;
   return inverse_permutation;

--- a/src/sparsebase/reorder/degree_reorder.cc
+++ b/src/sparsebase/reorder/degree_reorder.cc
@@ -26,23 +26,23 @@ IDType *DegreeReorder<IDType, NNZType, ValueType>::CalculateReorderCSR(
   DegreeReorderParams *cast_params = static_cast<DegreeReorderParams *>(params);
   bool ascending = cast_params->ascending;
   IDType n = csr->get_dimensions()[0];
-  IDType *counts = new IDType[n]();
+  IDType *counts = new IDType[n + 1]();
   auto row_ptr = csr->get_row_ptr();
   auto col = csr->get_col();
+
   for (IDType u = 0; u < n; u++) {
-    counts[row_ptr[u + 1] - row_ptr[u] + 1]++;
+    counts[row_ptr[u + 1] - row_ptr[u]]++;
   }
-  for (IDType u = 1; u < n; u++) {
+  for (IDType u = 1; u < n + 1; u++) {
     counts[u] += counts[u - 1];
   }
   IDType *sorted = new IDType[n];
   memset(sorted, -1, sizeof(IDType) * n);
   IDType *mr = new IDType[n]();
   for (IDType u = 0; u < n; u++) {
-    IDType deg = row_ptr[u + 1] - row_ptr[u];
-    IDType ec = counts[deg];
-    counts[deg]--;
-    sorted[ec - 1] = u;
+    IDType ec = counts[row_ptr[u + 1] - row_ptr[u]];
+    sorted[ec - mr[ec] - 1] = u;
+    mr[ec]++;
   }
   if (!ascending) {
     for (IDType i = 0; i < n / 2; i++) {

--- a/src/sparsebase/reorder/gray_reorder.cc
+++ b/src/sparsebase/reorder/gray_reorder.cc
@@ -89,7 +89,7 @@ bool GrayReorder<IDType, NNZType, ValueType>::is_banded(
     for (int i = row_ptr[order[r]]; i < row_ptr[order[r] + 1]; i++) {
       int col = cols[i];
       nnz_++;
-      if (abs(col - r) <= band_size) band_count++;
+      if ((int)abs(col - r) <= band_size) band_count++;
     }
   }
 
@@ -153,14 +153,14 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
       for (int j = csr->get_row_ptr()[i]; j < csr->get_row_ptr()[i + 1]; j++) {
         int col = csr->get_col()[j];
         nnz_sparse++;
-        if (abs(col - i) <= band_size) sparse_diagonal++;
+        if ((int)abs(col - i) <= band_size) sparse_diagonal++;
       }
     } else {
       dense_v_order.push_back(i);
       for (int j = csr->get_row_ptr()[i]; j < csr->get_row_ptr()[i + 1]; j++) {
         int col = csr->get_col()[j];
         nnz_dense++;
-        if (abs(col - i) <= band_size) dense_diagonal++;
+        if ((int)abs(col - i) <= band_size) dense_diagonal++;
       }
     }
   }

--- a/src/sparsebase/reorder/gray_reorder.cc
+++ b/src/sparsebase/reorder/gray_reorder.cc
@@ -110,6 +110,8 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
       static_cast<context::CPUContext *>(csr->get_context());
 
   IDType n_rows = csr->get_dimensions()[0];
+  IDType n_cols = csr->get_dimensions()[1];
+  
   /*This array stores the permutation vector such as order[0] = 243 means that
    * row 243 is the first row of the reordered matrix*/
   IDType *order = new IDType[n_rows]();
@@ -127,7 +129,7 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
   bool decresc_grey_order = false;
 
   int group_count = 0;
-
+ 
   /*added*/
   int sparse_diagonal = 0;
   int dense_diagonal = 0;
@@ -164,7 +166,6 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
       }
     }
   }
-
   v_order.reserve(sparse_v_order.size() +
                   dense_v_order.size());  // preallocate memory
 
@@ -199,7 +200,6 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
   } else {
     is_dense_banded = false;
   }
-
   std::sort(sparse_v_order.begin(), sparse_v_order.end(),
             [&](int i, int j) -> bool {
               return (csr->get_row_ptr()[i + 1] - csr->get_row_ptr()[i]) <
@@ -207,11 +207,11 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
             });  // reorder sparse matrix into nnz amount
 
   // the bit resolution determines the width of the bitmap of each row
-  if (n_rows < bit_resolution) {
-    bit_resolution = n_rows;
+  if (n_cols < bit_resolution) {
+    bit_resolution = n_cols;
   }
 
-  int row_split = n_rows / bit_resolution;
+  int row_split = n_cols / bit_resolution;
 
   auto nnz_per_row_split = new IDType[bit_resolution];
   auto nnz_per_row_split_bin = new IDType[bit_resolution];
@@ -224,7 +224,6 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
       reorder_section;  // vector that contains a section to be reordered
 
   reorder_section.reserve(n_rows);
-
   if (!is_sparse_banded) {  // if banded just row ordering by nnz count is
     // enough, else do bitmap reordering in groups
     for (int i = 0; i < sparse_v_order.size();
@@ -371,7 +370,6 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
     
     reorder_section.clear();
   }
-
   if (!is_dense_banded) {
     logger.Log("Rows [" + std::to_string(sparse_dense_split) + "-" +
                    std::to_string(n_rows) +
@@ -415,7 +413,6 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
 
     reorder_section.clear();
   }
-
   v_order.insert(v_order.end(), sparse_v_order.begin(), sparse_v_order.end());
   v_order.insert(v_order.end(), dense_v_order.begin(), dense_v_order.end());
 
@@ -425,8 +422,8 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
   for (int i = 0; i < n_rows; i++) {
     order[v_order[i]] = i;
   }
+
   // std::copy(v_order_inv.begin(), v_order_inv.end(), order);
-  
   return order;
 }
 

--- a/src/sparsebase/reorder/gray_reorder.cc
+++ b/src/sparsebase/reorder/gray_reorder.cc
@@ -89,7 +89,7 @@ bool GrayReorder<IDType, NNZType, ValueType>::is_banded(
     for (int i = row_ptr[order[r]]; i < row_ptr[order[r] + 1]; i++) {
       int col = cols[i];
       nnz_++;
-      if ((int)abs(col - r) <= band_size) band_count++;
+      if ((col >= r) ? (col - r <= band_size) : (r - col <= band_size)) band_count++;
     }
   }
 
@@ -153,14 +153,14 @@ IDType *GrayReorder<IDType, NNZType, ValueType>::GrayReorderingCSR(
       for (int j = csr->get_row_ptr()[i]; j < csr->get_row_ptr()[i + 1]; j++) {
         int col = csr->get_col()[j];
         nnz_sparse++;
-        if ((int)abs(col - i) <= band_size) sparse_diagonal++;
+        if ((col >= i) ? (col - i <= band_size) : (i - col <= band_size)) sparse_diagonal++;
       }
     } else {
       dense_v_order.push_back(i);
       for (int j = csr->get_row_ptr()[i]; j < csr->get_row_ptr()[i + 1]; j++) {
         int col = csr->get_col()[j];
         nnz_dense++;
-        if ((int)abs(col - i) <= band_size) dense_diagonal++;
+        if ((col >= i) ? (col - i <= band_size) : (i - col <= band_size)) dense_diagonal++;
       }
     }
   }

--- a/src/sparsebase/reorder/gray_reorder.h
+++ b/src/sparsebase/reorder/gray_reorder.h
@@ -12,8 +12,8 @@ namespace sparsebase::reorder {
 
 enum BitMapSize{
   BitSize16 = 16,
-  BitSize32 = 32/*,
-  BitSize64 = 64*/ //at the moment, using 64 bits is not working as intended
+  BitSize32 = 32,
+  BitSize64 = 64
 };
 //! Params struct for GrayReorder
 struct GrayReorderParams : utils::Parameters {
@@ -44,7 +44,7 @@ class GrayReorder : public Reorderer<IDType> {
   static bool asc_comparator(const row_grey_pair &l, const row_grey_pair &r);
 
   // not sure if all IDTypes work for this
-  static unsigned long grey_bin_to_dec(unsigned long n);
+  static unsigned long long grey_bin_to_dec(unsigned long long n);
 
   static void print_dec_in_bin(unsigned long n, int size);
 


### PR DESCRIPTION
Fix made to degree ordering:
- Previous implementation did not consider matrices where nodes can have maximum degree (degree=n). Would produce segmentation fault in these situations;
- Increased the memory allocated by the used vectors and fixed how the counting sort is made to accommodate these extreme cases.